### PR TITLE
msaa-line example fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ gl = ["wgn/gfx-backend-gl"]
 
 [dependencies]
 #TODO: only depend on the published version
-wgn = { package = "wgpu-native", version = "0.2.6", features = ["local", "window-winit"], git = "https://github.com/gfx-rs/wgpu", rev = "a667d50d01c3df03b8540c523278e111da7fc82a" }
+wgn = { package = "wgpu-native", version = "0.2.6", features = ["local", "window-winit"], git = "https://github.com/gfx-rs/wgpu", rev = "dbef9f397eda87b82ae1691b2f7e8ba0f3e2e5d2" }
 arrayvec = "0.4"
 
 [dev-dependencies]


### PR DESCRIPTION
This PR fixes the msaa-line example in addition to the fixes in https://github.com/gfx-rs/wgpu/pull/235

If https://github.com/gfx-rs/gfx/pull/2853 is merged first we can remove the crates.io patch.