### PR TITLE
Update running an example documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,37 @@ This is an idiomatic Rust wrapper over [wgpu-native](https://github.com/gfx-rs/w
 ## Usage
 
 The library requires one of the following features enabled in order to run any of the examples:
-  - "vulkan"
-  - "metal"
-  - "dx12"
-  - "dx11"
+  - Vulkan
+  - Metal
+  - DirectX 12 (Dx12)
+  - DirectX 11 (Dx11)
+  - OpenGL (Gl)
 
-These examples assume that necessary dependencies for the graphics backend are already installed. For more information about installation and usage, refer to the [Getting Started](https://github.com/gfx-rs/gfx/blob/master/info/getting_started.md) gfx-rs guide.
+These examples assume that necessary dependencies for the graphics backend are already installed. 
+
+### Running an example
+All examples are located under the [examples](examples) directory. We are using the default syntax for running examples, as found in the [Cargo](https://doc.rust-lang.org/cargo/reference/manifest.html#examples) documentation.
+
+#### Cube
+```bash
+cargo run --example cube --features metal
+cargo run --example cube --features vulkan
+cargo run --example cube --features dx12
+cargo run --example cube --features dx11
+cargo run --example cube --features gl
+```
+
+#### Hello Compute
+The "1", "2", "3", and "4" are arguments passed into the program. These arguments are used for the compute pipeline.
+```bash
+cargo run --example hello-compute --features metal 1 2 3 4
+cargo run --example hello-compute --features vulkan 1 2 3 4
+cargo run --example hello-compute --features dx12 1 2 3 4
+cargo run --example hello-compute --features dx11 1 2 3 4
+cargo run --example hello-compute --features gl 1 2 3 4
+```
+
+More examples can be found under the [examples](examples) directory.
 
 ## Friends
 


### PR DESCRIPTION
- Removed link to gfx getting started
- Created our own getting started (with examples)
- Updated syntax

Motivation: I always forget how to run the examples, gfx getting started is not the same as the wgpu-rs one. So I found the correct usage of the syntax to run examples. I am noticing in the Gitter channel that many people are struggling with running the examples, maybe this will clear it up a little. 

This is the beginning, I will continue to expand the documentation in the future.