### PR TITLE
Replace the has been deprecated glsl-to-spirv with shaderc-rs crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,6 @@ arrayvec = "0.4"
 [dev-dependencies]
 cgmath = "0.17"
 env_logger = "0.6"
-glsl-to-spirv = "0.1"
+shaderc = "0.6"
 log = "0.4"
 png = "0.15"


### PR DESCRIPTION
Since ```glsl-to-spirv``` has been deprecated, [wgpu-rs/issues/36](https://github.com/gfx-rs/wgpu-rs/issues/36) is related to glsl spec, and [glslc](https://github.com/google/shaderc/tree/master/glslc) is still iterating fast, use ```shaderc-rs``` to follow up on future updates from ```glslc```  .

### Extra information
compile ```shaderc-rs``` need to install ```Pathon``` 3, and maybe  need to remove local computer’s ```CMakeCache.txt``` file to let cmake use latest Pathon version.

If the following error message appears when compiling on macOS: 
```
CMake Error at .../CMakeTestCXXCompiler.cmake:53 (message):
  The C++ compiler
  ...
  is not able to compile a simple test program.
  ```
Make sure have XCode installed as well as command line tools: ```xcode-select --install```