### PR TITLE
Use `HasRawWindowHandle` in `create_surface`

### DIFF
--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -54,16 +54,13 @@ pub fn run<E: Example>(title: &str) {
 
     #[cfg(not(feature = "gl"))]
     let (_window, instance, hidpi_factor, size, surface) = {
-        use raw_window_handle::HasRawWindowHandle as _;
-
-
         let window = winit::window::Window::new(&event_loop).unwrap();
         window.set_title(title);
         let hidpi_factor = window.hidpi_factor();
         let size = window.inner_size().to_physical(hidpi_factor);
 
         let instance = wgpu::Instance::new();
-        let surface = instance.create_surface(window.raw_window_handle());
+        let surface = instance.create_surface(&window);
 
         (window, instance, hidpi_factor, size, surface)
     };

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -9,15 +9,13 @@ fn main() {
 
     #[cfg(not(feature = "gl"))]
     let (_window, instance, size, surface) = {
-        use raw_window_handle::HasRawWindowHandle as _;
-
         let window = winit::window::Window::new(&event_loop).unwrap();
         let size = window
             .inner_size()
             .to_physical(window.hidpi_factor());
 
         let instance = wgpu::Instance::new();
-        let surface = instance.create_surface(window.raw_window_handle());
+        let surface = instance.create_surface(&window);
 
         (window, instance, size, surface)
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,9 +560,9 @@ impl Instance {
 
     /// Creates a surface from a raw window handle.
     #[cfg(not(feature = "gl"))]
-    pub fn create_surface(&self, raw_handle: raw_window_handle::RawWindowHandle) -> Surface {
+    pub fn create_surface<W: raw_window_handle::HasRawWindowHandle>(&self, window: &W) -> Surface {
         Surface {
-            id: wgn::wgpu_instance_create_surface(self.id, raw_handle),
+            id: wgn::wgpu_instance_create_surface(self.id, window.raw_window_handle()),
         }
     }
 


### PR DESCRIPTION
This change lets users use `wgpu` without listing `raw-window-handle` as a direct dependency themselves.