### PR TITLE
Update wgpu-native to the commit that has no backend features.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,4 @@ branches:
 
 script:
   - cargo check
-  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then cargo test --no-run --features vulkan; fi
-  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then cargo test --no-run --features metal; fi
-  - if [[ $TRAVIS_OS_NAME == "windows" ]]; then cargo test --no-run --features dx12; fi
+  - cargo test --no-run

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,9 @@ license = "MPL-2.0"
 
 [features]
 default = []
-metal = ["wgn/gfx-backend-metal"]
-dx11 = ["wgn/gfx-backend-dx11"]
-dx12 = ["wgn/gfx-backend-dx12"]
-vulkan = ["wgn/gfx-backend-vulkan"]
-#TODO: there is no way to use glutin-0.20 with GL backend v0.3 yet
-#gl = ["wgn/gfx-backend-gl"]
 
 [dependencies]
-wgn = { package = "wgpu-native", version = "0.3.1", features = ["local"] }
+wgn = { package = "wgpu-native", git = "https://github.com/gfx-rs/wgpu", rev = "b58c96e4a66943e09e9a9aa0ee8345c7bc878d38" }
 arrayvec = "0.4"
 raw-window-handle = "0.1"
 zerocopy = "0.2"

--- a/README.md
+++ b/README.md
@@ -12,35 +12,20 @@ This is an idiomatic Rust wrapper over [wgpu-native](https://github.com/gfx-rs/w
 
 ## Usage
 
-The library requires one of the following features enabled in order to run any of the examples:
-  - Vulkan
-  - Metal
-  - DirectX 12 (Dx12)
-  - DirectX 11 (Dx11)
-  - OpenGL (Gl)
-
-These examples assume that necessary dependencies for the graphics backend are already installed. 
-
 ### Running an example
 All examples are located under the [examples](examples) directory. We are using the default syntax for running examples, as found in the [Cargo](https://doc.rust-lang.org/cargo/reference/manifest.html#examples) documentation.
 
-#### Cube
 ```bash
-cargo run --example cube --features metal
-cargo run --example cube --features vulkan
-cargo run --example cube --features dx12
-cargo run --example cube --features dx11
-cargo run --example cube --features gl
+cargo run --example cube
 ```
 
 #### Hello Compute
-The "1", "2", "3", and "4" are arguments passed into the program. These arguments are used for the compute pipeline.
+
+`hello-*` examples show barebones setup without any helper code.
+
+For "hello-compute", pass 4 numbers separated by spaces as arguments:
 ```bash
-cargo run --example hello-compute --features metal 1 2 3 4
-cargo run --example hello-compute --features vulkan 1 2 3 4
-cargo run --example hello-compute --features dx12 1 2 3 4
-cargo run --example hello-compute --features dx11 1 2 3 4
-cargo run --example hello-compute --features gl 1 2 3 4
+cargo run --example hello-compute 1 2 3 4
 ```
 
 More examples can be found under the [examples](examples) directory.
@@ -50,6 +35,7 @@ More examples can be found under the [examples](examples) directory.
 Shout out to the following projects that work best with wgpu-rs:
   - [wgpu_glyph](https://github.com/hecrj/wgpu_glyph) - for your text-y rendering needs
   - [coffee](https://github.com/hecrj/coffee) - a whole 2D engine
+  - [rgx](https://github.com/cloudhead/rgx) - a 2D graphics library
   - [imgui-wgpu](https://github.com/unconed/imgui-wgpu-rs) - Dear ImGui interfacing
 
 ## Development

--- a/examples/capture/main.rs
+++ b/examples/capture/main.rs
@@ -7,11 +7,10 @@ use std::mem::size_of;
 fn main() {
     env_logger::init();
 
-    let instance = wgpu::Instance::new();
-
-    let adapter = instance.request_adapter(&wgpu::RequestAdapterOptions {
+    let adapter = wgpu::Adapter::request(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::LowPower,
-    });
+        backends: wgpu::BackendBit::PRIMARY,
+    }).unwrap();
 
     let mut device = adapter.request_device(&wgpu::DeviceDescriptor {
         extensions: wgpu::Extensions {

--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -53,16 +53,13 @@ pub fn run<E: Example>(title: &str) {
     info!("Initializing the window...");
 
     #[cfg(not(feature = "gl"))]
-    let (_window, instance, hidpi_factor, size, surface) = {
+    let (_window, hidpi_factor, size, surface) = {
         let window = winit::window::Window::new(&event_loop).unwrap();
         window.set_title(title);
         let hidpi_factor = window.hidpi_factor();
         let size = window.inner_size().to_physical(hidpi_factor);
-
-        let instance = wgpu::Instance::new();
-        let surface = instance.create_surface(&window);
-
-        (window, instance, hidpi_factor, size, surface)
+        let surface = wgpu::Surface::create(&window);
+        (window, hidpi_factor, size, surface)
     };
 
     #[cfg(feature = "gl")]
@@ -87,9 +84,10 @@ pub fn run<E: Example>(title: &str) {
         (window, instance, hidpi_factor, size, surface)
     };
 
-    let adapter = instance.request_adapter(&wgpu::RequestAdapterOptions {
+    let adapter = wgpu::Adapter::request(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::LowPower,
-    });
+        backends: wgpu::BackendBit::PRIMARY,
+    }).unwrap();
 
     let mut device = adapter.request_device(&wgpu::DeviceDescriptor {
         extensions: wgpu::Extensions {

--- a/examples/hello-compute/main.rs
+++ b/examples/hello-compute/main.rs
@@ -14,10 +14,10 @@ fn main() {
 
     let size = (numbers.len() * std::mem::size_of::<u32>()) as wgpu::BufferAddress;
 
-    let instance = wgpu::Instance::new();
-    let adapter = instance.request_adapter(&wgpu::RequestAdapterOptions {
+    let adapter = wgpu::Adapter::request(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::Default,
-    });
+        backends: wgpu::BackendBit::PRIMARY,
+    }).unwrap();
 
     let mut device = adapter.request_device(&wgpu::DeviceDescriptor {
         extensions: wgpu::Extensions {

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -8,16 +8,14 @@ fn main() {
     let event_loop = EventLoop::new();
 
     #[cfg(not(feature = "gl"))]
-    let (_window, instance, size, surface) = {
+    let (_window, size, surface) = {
         let window = winit::window::Window::new(&event_loop).unwrap();
         let size = window
             .inner_size()
             .to_physical(window.hidpi_factor());
 
-        let instance = wgpu::Instance::new();
-        let surface = instance.create_surface(&window);
-
-        (window, instance, size, surface)
+        let surface = wgpu::Surface::create(&window);
+        (window, size, surface)
     };
 
     #[cfg(feature = "gl")]
@@ -40,9 +38,10 @@ fn main() {
         (window, instance, size, surface)
     };
 
-    let adapter = instance.request_adapter(&wgpu::RequestAdapterOptions {
+    let adapter = wgpu::Adapter::request(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::LowPower,
-    });
+        backends: wgpu::BackendBit::PRIMARY,
+    }).unwrap();
 
     let mut device = adapter.request_device(&wgpu::DeviceDescriptor {
         extensions: wgpu::Extensions {


### PR DESCRIPTION
This change removes the dependency on gfx-rs backends, refactors
Adapter and Surface creation to be done from nothing.