### PR TITLE
Return Queue separately

### DIFF
--- a/examples/capture/main.rs
+++ b/examples/capture/main.rs
@@ -12,7 +12,7 @@ fn main() {
         backends: wgpu::BackendBit::PRIMARY,
     }).unwrap();
 
-    let mut device = adapter.request_device(&wgpu::DeviceDescriptor {
+    let (device, mut queue) = adapter.request_device(&wgpu::DeviceDescriptor {
         extensions: wgpu::Extensions {
             anisotropic_filtering: false,
         },
@@ -80,7 +80,7 @@ fn main() {
         encoder.finish()
     };
 
-    device.get_queue().submit(&[command_buffer]);
+    queue.submit(&[command_buffer]);
 
     // Write the buffer as a PNG
     output_buffer.map_read_async(

--- a/examples/hello-compute/main.rs
+++ b/examples/hello-compute/main.rs
@@ -19,7 +19,7 @@ fn main() {
         backends: wgpu::BackendBit::PRIMARY,
     }).unwrap();
 
-    let mut device = adapter.request_device(&wgpu::DeviceDescriptor {
+    let (device, mut queue) = adapter.request_device(&wgpu::DeviceDescriptor {
         extensions: wgpu::Extensions {
             anisotropic_filtering: false,
         },
@@ -88,7 +88,7 @@ fn main() {
     }
     encoder.copy_buffer_to_buffer(&storage_buffer, 0, &staging_buffer, 0, size);
 
-    device.get_queue().submit(&[encoder.finish()]);
+    queue.submit(&[encoder.finish()]);
 
     staging_buffer.map_read_async(0, size, |result: wgpu::BufferMapAsyncResult<&[u32]>| {
         if let Ok(mapping) = result {

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -43,7 +43,7 @@ fn main() {
         backends: wgpu::BackendBit::PRIMARY,
     }).unwrap();
 
-    let mut device = adapter.request_device(&wgpu::DeviceDescriptor {
+    let (device, mut queue) = adapter.request_device(&wgpu::DeviceDescriptor {
         extensions: wgpu::Extensions {
             anisotropic_filtering: false,
         },
@@ -152,7 +152,7 @@ fn main() {
                     rpass.draw(0 .. 3, 0 .. 1);
                 }
 
-                device.get_queue().submit(&[encoder.finish()]);
+                queue.submit(&[encoder.finish()]);
             }
             _ => (),
         }


### PR DESCRIPTION
What problem is this PR trying to solve? We want `Device` to be freely accessible from multiple threads/objects and internally synchronized. `Arc<Device>` seems like a natural choice of such a sharable object, especially since all except one methods are `&self`.

That one method is `get_queue()`, and it returns a temporary object `Queue<'a>`. If we turn it into `&self`, we'd end up with multiple instances of `Queue` created at any time, which contradicts the initial design (of this Rust wrapper). If it stays `&mut` and the user wraps the device into `Arc`, they'll never be able to submit any work...

So this PR solves this by moving the `Queue` completely outside of the device.