### PR TITLE
Propagate making Vulkan backend available to wgpu-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ license = "MPL-2.0"
 
 [features]
 default = []
+# Make Vulkan backend available on platforms where it is by default not, e.g. macOS
+vulkan = ["wgn/gfx-backend-vulkan"]
 
 [dependencies]
 wgn = { package = "wgpu-native", git = "https://github.com/gfx-rs/wgpu", rev = "499bf1d2686ad25b5a5133d6433e4f4c9179ff0b" }


### PR DESCRIPTION
`wgpu-native` has `gfx-backend-vulkan` feature which makes Vulkan available on macOS. This adds the feature to `wgpu-rs` also.