### PR TITLE
Adapter::get_info

### DIFF
--- a/examples/describe/main.rs
+++ b/examples/describe/main.rs
@@ -1,0 +1,11 @@
+/// This example shows how to describe the adapter in use.
+fn main() {
+    env_logger::init();
+
+    let adapter = wgpu::Adapter::request(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::Default,
+        backends: wgpu::BackendBit::PRIMARY,
+    }).unwrap();
+
+    println!("{:?}", adapter.get_info())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ use std::slice;
 use std::thread;
 
 pub use wgn::{
+    AdapterInfo,
     AddressMode,
     BackendBit,
     BlendDescriptor,
@@ -560,6 +561,10 @@ impl Adapter {
             temp_command_buffers: Vec::new(),
         };
         (device, queue)
+    }
+
+    pub fn get_info(&self) -> AdapterInfo {
+        wgn::wgpu_adapter_get_info(self.id)
     }
 }
 


### PR DESCRIPTION
This more or less addresses #7.

If the example is too trivial, I'm happy to remove it.