### PR TITLE
build: exclude necessities for packaging, fixes #112

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ homepage = "https://github.com/gfx-rs/wgpu-rs"
 repository = "https://github.com/gfx-rs/wgpu-rs"
 keywords = ["graphics"]
 license = "MPL-2.0"
+exclude = ["etc/**/*", "examples/**/*", "tests/**/*", "Cargo.lock", "target/**/*"]
 
 [lib]
 


### PR DESCRIPTION
I believe this is the minimal set required as an external dep, e.g., don't need tests, etc., and other folders. I can't seem to find any explicit recommendations here though: https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields-optional
