### PR TITLE
Handle error case for SwapChain::get_next_texture

### DIFF
--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -162,7 +162,8 @@ pub fn run<E: Example>(title: &str) {
                 }
             },
             event::Event::EventsCleared => {
-                let frame = swap_chain.get_next_texture();
+                let frame = swap_chain.get_next_texture()
+                    .expect("Timeout when acquiring next swap chain texture");
                 let command_buf = example.render(&frame, &device);
                 queue.submit(&[command_buf]);
             }

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -133,7 +133,8 @@ fn main() {
                 _ => {}
             },
             event::Event::EventsCleared => {
-                let frame = swap_chain.get_next_texture();
+                let frame = swap_chain.get_next_texture()
+                    .expect("Timeout when acquiring next swap chain texture");
                 let mut encoder =
                     device.create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
                 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1351,14 +1351,20 @@ impl SwapChain {
     ///
     /// When the [`SwapChainOutput`] returned by this method is dropped, the swapchain will present
     /// the texture to the associated [`Surface`].
-    pub fn get_next_texture(&mut self) -> SwapChainOutput {
+    ///
+    /// Returns an `Err` if the GPU timed out when attempting to acquire the next texture.
+    pub fn get_next_texture(&mut self) -> Result<SwapChainOutput, ()> {
         let output = wgn::wgpu_swap_chain_get_next_texture(self.id);
-        SwapChainOutput {
-            view: TextureView {
-                id: output.view_id,
-                owned: false,
-            },
-            swap_chain_id: &self.id,
+        if output.view_id == wgn::Id::ERROR {
+            Err(())
+        } else {
+            Ok(SwapChainOutput {
+                view: TextureView {
+                    id: output.view_id,
+                    owned: false,
+                },
+                swap_chain_id: &self.id,
+            })
         }
     }
 }


### PR DESCRIPTION
Updates `SwapChain::get_next_texture` to account for https://github.com/gfx-rs/wgpu/pull/369. Otherwise, an invalid `Id` is returned and may cause confusing errors.