### PR TITLE
Safety of buffer mapping

### DIFF
--- a/examples/capture/main.rs
+++ b/examples/capture/main.rs
@@ -10,7 +10,8 @@ fn main() {
     let adapter = wgpu::Adapter::request(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::Default,
         backends: wgpu::BackendBit::PRIMARY,
-    }).unwrap();
+    })
+    .unwrap();
 
     let (device, mut queue) = adapter.request_device(&wgpu::DeviceDescriptor {
         extensions: wgpu::Extensions {

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -106,7 +106,10 @@ impl Example {
 }
 
 impl framework::Example for Example {
-    fn init(sc_desc: &wgpu::SwapChainDescriptor, device: &wgpu::Device) -> (Self, Option<wgpu::CommandBuffer>) {
+    fn init(
+        sc_desc: &wgpu::SwapChainDescriptor,
+        device: &wgpu::Device,
+    ) -> (Self, Option<wgpu::CommandBuffer>) {
         use std::mem;
 
         let mut init_encoder =
@@ -129,9 +132,7 @@ impl framework::Example for Example {
                 wgpu::BindGroupLayoutBinding {
                     binding: 0,
                     visibility: wgpu::ShaderStage::VERTEX,
-                    ty: wgpu::BindingType::UniformBuffer {
-                        dynamic: false,
-                    },
+                    ty: wgpu::BindingType::UniformBuffer { dynamic: false },
                 },
                 wgpu::BindGroupLayoutBinding {
                     binding: 1,
@@ -208,10 +209,7 @@ impl framework::Example for Example {
         let mx_total = Self::generate_matrix(sc_desc.width as f32 / sc_desc.height as f32);
         let mx_ref: &[f32; 16] = mx_total.as_ref();
         let uniform_buf = device
-            .create_buffer_mapped(
-                16,
-                wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
-            )
+            .create_buffer_mapped(16, wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST)
             .fill_from_slice(mx_ref);
 
         // Create bind group
@@ -309,7 +307,11 @@ impl framework::Example for Example {
         //empty
     }
 
-    fn resize(&mut self, sc_desc: &wgpu::SwapChainDescriptor, device: &wgpu::Device) -> Option<wgpu::CommandBuffer> {
+    fn resize(
+        &mut self,
+        sc_desc: &wgpu::SwapChainDescriptor,
+        device: &wgpu::Device,
+    ) -> Option<wgpu::CommandBuffer> {
         let mx_total = Self::generate_matrix(sc_desc.width as f32 / sc_desc.height as f32);
         let mx_ref: &[f32; 16] = mx_total.as_ref();
 
@@ -323,7 +325,11 @@ impl framework::Example for Example {
         Some(encoder.finish())
     }
 
-    fn render(&mut self, frame: &wgpu::SwapChainOutput, device: &wgpu::Device) -> wgpu::CommandBuffer {
+    fn render(
+        &mut self,
+        frame: &wgpu::SwapChainOutput,
+        device: &wgpu::Device,
+    ) -> wgpu::CommandBuffer {
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
         {

--- a/examples/describe/main.rs
+++ b/examples/describe/main.rs
@@ -5,7 +5,8 @@ fn main() {
     let adapter = wgpu::Adapter::request(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::Default,
         backends: wgpu::BackendBit::PRIMARY,
-    }).unwrap();
+    })
+    .unwrap();
 
     println!("{:?}", adapter.get_info())
 }

--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -162,7 +162,8 @@ pub fn run<E: Example>(title: &str) {
                 }
             },
             event::Event::EventsCleared => {
-                let frame = swap_chain.get_next_texture()
+                let frame = swap_chain
+                    .get_next_texture()
                     .expect("Timeout when acquiring next swap chain texture");
                 let command_buf = example.render(&frame, &device);
                 queue.submit(&[command_buf]);

--- a/examples/hello-compute/main.rs
+++ b/examples/hello-compute/main.rs
@@ -17,7 +17,8 @@ fn main() {
     let adapter = wgpu::Adapter::request(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::Default,
         backends: wgpu::BackendBit::PRIMARY,
-    }).unwrap();
+    })
+    .unwrap();
 
     let (device, mut queue) = adapter.request_device(&wgpu::DeviceDescriptor {
         extensions: wgpu::Extensions {
@@ -27,14 +28,13 @@ fn main() {
     });
 
     let cs = include_bytes!("shader.comp.spv");
-    let cs_module = device.create_shader_module(&wgpu::read_spirv(std::io::Cursor::new(&cs[..])).unwrap());
+    let cs_module =
+        device.create_shader_module(&wgpu::read_spirv(std::io::Cursor::new(&cs[..])).unwrap());
 
     let staging_buffer = device
         .create_buffer_mapped(
             numbers.len(),
-            wgpu::BufferUsage::MAP_READ
-                | wgpu::BufferUsage::COPY_DST
-                | wgpu::BufferUsage::COPY_SRC,
+            wgpu::BufferUsage::MAP_READ | wgpu::BufferUsage::COPY_DST | wgpu::BufferUsage::COPY_SRC,
         )
         .fill_from_slice(&numbers);
 
@@ -46,13 +46,14 @@ fn main() {
     });
 
     let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-        bindings: &[
-            wgpu::BindGroupLayoutBinding {
-                binding: 0,
-                visibility: wgpu::ShaderStage::COMPUTE,
-                ty: wgpu::BindingType::StorageBuffer { dynamic: false, readonly: false },
+        bindings: &[wgpu::BindGroupLayoutBinding {
+            binding: 0,
+            visibility: wgpu::ShaderStage::COMPUTE,
+            ty: wgpu::BindingType::StorageBuffer {
+                dynamic: false,
+                readonly: false,
             },
-        ],
+        }],
     });
 
     let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -1,7 +1,7 @@
 fn main() {
     use winit::{
-        event_loop::{ControlFlow, EventLoop},
         event,
+        event_loop::{ControlFlow, EventLoop},
     };
 
     env_logger::init();
@@ -10,9 +10,7 @@ fn main() {
     #[cfg(not(feature = "gl"))]
     let (_window, size, surface) = {
         let window = winit::window::Window::new(&event_loop).unwrap();
-        let size = window
-            .inner_size()
-            .to_physical(window.hidpi_factor());
+        let size = window.inner_size().to_physical(window.hidpi_factor());
 
         let surface = wgpu::Surface::create(&window);
         (window, size, surface)
@@ -41,7 +39,8 @@ fn main() {
     let adapter = wgpu::Adapter::request(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::Default,
         backends: wgpu::BackendBit::PRIMARY,
-    }).unwrap();
+    })
+    .unwrap();
 
     let (device, mut queue) = adapter.request_device(&wgpu::DeviceDescriptor {
         extensions: wgpu::Extensions {
@@ -51,14 +50,15 @@ fn main() {
     });
 
     let vs = include_bytes!("shader.vert.spv");
-    let vs_module = device.create_shader_module(&wgpu::read_spirv(std::io::Cursor::new(&vs[..])).unwrap());
+    let vs_module =
+        device.create_shader_module(&wgpu::read_spirv(std::io::Cursor::new(&vs[..])).unwrap());
 
     let fs = include_bytes!("shader.frag.spv");
-    let fs_module = device.create_shader_module(&wgpu::read_spirv(std::io::Cursor::new(&fs[..])).unwrap());
+    let fs_module =
+        device.create_shader_module(&wgpu::read_spirv(std::io::Cursor::new(&fs[..])).unwrap());
 
-    let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-        bindings: &[],
-    });
+    let bind_group_layout =
+        device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor { bindings: &[] });
     let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
         layout: &bind_group_layout,
         bindings: &[],
@@ -133,7 +133,8 @@ fn main() {
                 _ => {}
             },
             event::Event::EventsCleared => {
-                let frame = swap_chain.get_next_texture()
+                let frame = swap_chain
+                    .get_next_texture()
                     .expect("Timeout when acquiring next swap chain texture");
                 let mut encoder =
                     device.create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -95,14 +95,10 @@ impl Example {
             bind_group_layouts: &[&bind_group_layout],
         });
 
-        let vs_bytes = framework::load_glsl(
-            include_str!("blit.vert"),
-            framework::ShaderStage::Vertex,
-        );
-        let fs_bytes = framework::load_glsl(
-            include_str!("blit.frag"),
-            framework::ShaderStage::Fragment,
-        );
+        let vs_bytes =
+            framework::load_glsl(include_str!("blit.vert"), framework::ShaderStage::Vertex);
+        let fs_bytes =
+            framework::load_glsl(include_str!("blit.frag"), framework::ShaderStage::Fragment);
         let vs_module = device.create_shader_module(&vs_bytes);
         let fs_module = device.create_shader_module(&fs_bytes);
 
@@ -151,15 +147,17 @@ impl Example {
         });
 
         let views = (0 .. mip_count)
-            .map(|mip| texture.create_view(&wgpu::TextureViewDescriptor {
-                format: TEXTURE_FORMAT,
-                dimension: wgpu::TextureViewDimension::D2,
-                aspect: wgpu::TextureAspect::All,
-                base_mip_level: mip,
-                level_count: 1,
-                base_array_layer: 0,
-                array_layer_count: 1,
-            }))
+            .map(|mip| {
+                texture.create_view(&wgpu::TextureViewDescriptor {
+                    format: TEXTURE_FORMAT,
+                    dimension: wgpu::TextureViewDimension::D2,
+                    aspect: wgpu::TextureAspect::All,
+                    base_mip_level: mip,
+                    level_count: 1,
+                    base_array_layer: 0,
+                    array_layer_count: 1,
+                })
+            })
             .collect::<Vec<_>>();
 
         for target_mip in 1 .. mip_count as usize {
@@ -195,7 +193,10 @@ impl Example {
 }
 
 impl framework::Example for Example {
-    fn init(sc_desc: &wgpu::SwapChainDescriptor, device: &wgpu::Device) -> (Self, Option<wgpu::CommandBuffer>) {
+    fn init(
+        sc_desc: &wgpu::SwapChainDescriptor,
+        device: &wgpu::Device,
+    ) -> (Self, Option<wgpu::CommandBuffer>) {
         use std::mem;
 
         let mut init_encoder =
@@ -214,9 +215,7 @@ impl framework::Example for Example {
                 wgpu::BindGroupLayoutBinding {
                     binding: 0,
                     visibility: wgpu::ShaderStage::VERTEX,
-                    ty: wgpu::BindingType::UniformBuffer {
-                        dynamic: false,
-                    },
+                    ty: wgpu::BindingType::UniformBuffer { dynamic: false },
                 },
                 wgpu::BindGroupLayoutBinding {
                     binding: 1,
@@ -253,7 +252,9 @@ impl framework::Example for Example {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: TEXTURE_FORMAT,
-            usage: wgpu::TextureUsage::SAMPLED | wgpu::TextureUsage::OUTPUT_ATTACHMENT | wgpu::TextureUsage::COPY_DST,
+            usage: wgpu::TextureUsage::SAMPLED
+                | wgpu::TextureUsage::OUTPUT_ATTACHMENT
+                | wgpu::TextureUsage::COPY_DST,
         });
         let texture_view = texture.create_default_view();
         let temp_buf = device
@@ -294,10 +295,7 @@ impl framework::Example for Example {
         let mx_total = Self::generate_matrix(sc_desc.width as f32 / sc_desc.height as f32);
         let mx_ref: &[f32; 16] = mx_total.as_ref();
         let uniform_buf = device
-            .create_buffer_mapped(
-                16,
-                wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
-            )
+            .create_buffer_mapped(16, wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST)
             .fill_from_slice(mx_ref);
 
         // Create bind group
@@ -323,14 +321,10 @@ impl framework::Example for Example {
         });
 
         // Create the render pipeline
-        let vs_bytes = framework::load_glsl(
-            include_str!("draw.vert"),
-            framework::ShaderStage::Vertex,
-        );
-        let fs_bytes = framework::load_glsl(
-            include_str!("draw.frag"),
-            framework::ShaderStage::Fragment,
-        );
+        let vs_bytes =
+            framework::load_glsl(include_str!("draw.vert"), framework::ShaderStage::Vertex);
+        let fs_bytes =
+            framework::load_glsl(include_str!("draw.frag"), framework::ShaderStage::Fragment);
         let vs_module = device.create_shader_module(&vs_bytes);
         let fs_module = device.create_shader_module(&fs_bytes);
 
@@ -363,13 +357,11 @@ impl framework::Example for Example {
             vertex_buffers: &[wgpu::VertexBufferDescriptor {
                 stride: vertex_size as wgpu::BufferAddress,
                 step_mode: wgpu::InputStepMode::Vertex,
-                attributes: &[
-                    wgpu::VertexAttributeDescriptor {
-                        format: wgpu::VertexFormat::Float4,
-                        offset: 0,
-                        shader_location: 0,
-                    },
-                ],
+                attributes: &[wgpu::VertexAttributeDescriptor {
+                    format: wgpu::VertexFormat::Float4,
+                    offset: 0,
+                    shader_location: 0,
+                }],
             }],
             sample_count: 1,
             sample_mask: !0,
@@ -392,7 +384,11 @@ impl framework::Example for Example {
         //empty
     }
 
-    fn resize(&mut self, sc_desc: &wgpu::SwapChainDescriptor, device: &wgpu::Device) -> Option<wgpu::CommandBuffer> {
+    fn resize(
+        &mut self,
+        sc_desc: &wgpu::SwapChainDescriptor,
+        device: &wgpu::Device,
+    ) -> Option<wgpu::CommandBuffer> {
         let mx_total = Self::generate_matrix(sc_desc.width as f32 / sc_desc.height as f32);
         let mx_ref: &[f32; 16] = mx_total.as_ref();
 
@@ -406,7 +402,11 @@ impl framework::Example for Example {
         Some(encoder.finish())
     }
 
-    fn render(&mut self, frame: &wgpu::SwapChainOutput, device: &wgpu::Device) -> wgpu::CommandBuffer {
+    fn render(
+        &mut self,
+        frame: &wgpu::SwapChainOutput,
+        device: &wgpu::Device,
+    ) -> wgpu::CommandBuffer {
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
         {

--- a/examples/msaa-line/main.rs
+++ b/examples/msaa-line/main.rs
@@ -12,7 +12,7 @@ mod framework;
 
 #[derive(Clone, Copy)]
 struct Vertex {
-    _pos:   [f32; 2],
+    _pos: [f32; 2],
     _color: [f32; 4],
 }
 
@@ -30,7 +30,14 @@ struct Example {
 }
 
 impl Example {
-    fn create_pipeline(device: &wgpu::Device, sc_desc: &wgpu::SwapChainDescriptor, vs_module: &wgpu::ShaderModule, fs_module: &wgpu::ShaderModule, pipeline_layout: &wgpu::PipelineLayout, sample_count: u32) -> wgpu::RenderPipeline {
+    fn create_pipeline(
+        device: &wgpu::Device,
+        sc_desc: &wgpu::SwapChainDescriptor,
+        vs_module: &wgpu::ShaderModule,
+        fs_module: &wgpu::ShaderModule,
+        pipeline_layout: &wgpu::PipelineLayout,
+        sample_count: u32,
+    ) -> wgpu::RenderPipeline {
         println!("sample_count: {}", sample_count);
         device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             layout: &pipeline_layout,
@@ -80,7 +87,11 @@ impl Example {
         })
     }
 
-    fn create_multisampled_framebuffer(device: &wgpu::Device, sc_desc: &wgpu::SwapChainDescriptor, sample_count: u32) -> wgpu::TextureView {
+    fn create_multisampled_framebuffer(
+        device: &wgpu::Device,
+        sc_desc: &wgpu::SwapChainDescriptor,
+        sample_count: u32,
+    ) -> wgpu::TextureView {
         let multisampled_texture_extent = wgpu::Extent3d {
             width: sc_desc.width,
             height: sc_desc.height,
@@ -96,17 +107,26 @@ impl Example {
             usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
         };
 
-        device.create_texture(multisampled_frame_descriptor).create_default_view()
+        device
+            .create_texture(multisampled_frame_descriptor)
+            .create_default_view()
     }
 }
 
 impl framework::Example for Example {
-    fn init(sc_desc: &wgpu::SwapChainDescriptor, device: &wgpu::Device) -> (Self, Option<wgpu::CommandBuffer>) {
+    fn init(
+        sc_desc: &wgpu::SwapChainDescriptor,
+        device: &wgpu::Device,
+    ) -> (Self, Option<wgpu::CommandBuffer>) {
         println!("Press left/right arrow keys to change sample_count.");
         let sample_count = 4;
 
-        let vs_bytes = framework::load_glsl(include_str!("shader.vert"), framework::ShaderStage::Vertex);
-        let fs_bytes = framework::load_glsl(include_str!("shader.frag"), framework::ShaderStage::Fragment);
+        let vs_bytes =
+            framework::load_glsl(include_str!("shader.vert"), framework::ShaderStage::Vertex);
+        let fs_bytes = framework::load_glsl(
+            include_str!("shader.frag"),
+            framework::ShaderStage::Fragment,
+        );
         let vs_module = device.create_shader_module(&vs_bytes);
         let fs_module = device.create_shader_module(&fs_bytes);
 
@@ -114,13 +134,21 @@ impl framework::Example for Example {
             bind_group_layouts: &[],
         });
 
-        let pipeline = Example::create_pipeline(device, &sc_desc, &vs_module, &fs_module, &pipeline_layout, sample_count);
-        let multisampled_framebuffer = Example::create_multisampled_framebuffer(device, sc_desc, sample_count);
+        let pipeline = Example::create_pipeline(
+            device,
+            &sc_desc,
+            &vs_module,
+            &fs_module,
+            &pipeline_layout,
+            sample_count,
+        );
+        let multisampled_framebuffer =
+            Example::create_multisampled_framebuffer(device, sc_desc, sample_count);
 
-        let mut vertex_data = vec!();
+        let mut vertex_data = vec![];
 
         let max = 50;
-        for i in 0..max {
+        for i in 0 .. max {
             let percent = i as f32 / max as f32;
             let (sin, cos) = (percent * 2.0 * std::f32::consts::PI).sin_cos();
             vertex_data.push(Vertex {
@@ -170,28 +198,46 @@ impl framework::Example for Example {
                                 self.rebuild_pipeline = true;
                             }
                         }
-                        _ => { }
+                        _ => {}
                     }
                 }
             }
-            _ => { }
+            _ => {}
         }
     }
 
-    fn resize(&mut self, sc_desc: &wgpu::SwapChainDescriptor, device: &wgpu::Device) -> Option<wgpu::CommandBuffer> {
+    fn resize(
+        &mut self,
+        sc_desc: &wgpu::SwapChainDescriptor,
+        device: &wgpu::Device,
+    ) -> Option<wgpu::CommandBuffer> {
         self.sc_desc = sc_desc.clone();
-        self.multisampled_framebuffer = Example::create_multisampled_framebuffer(device, sc_desc, self.sample_count);
+        self.multisampled_framebuffer =
+            Example::create_multisampled_framebuffer(device, sc_desc, self.sample_count);
         None
     }
 
-    fn render(&mut self, frame: &wgpu::SwapChainOutput, device: &wgpu::Device) -> wgpu::CommandBuffer {
+    fn render(
+        &mut self,
+        frame: &wgpu::SwapChainOutput,
+        device: &wgpu::Device,
+    ) -> wgpu::CommandBuffer {
         if self.rebuild_pipeline {
-            self.pipeline = Example::create_pipeline(device, &self.sc_desc, &self.vs_module, &self.fs_module, &self.pipeline_layout, self.sample_count);
-            self.multisampled_framebuffer = Example::create_multisampled_framebuffer(device, &self.sc_desc, self.sample_count);
+            self.pipeline = Example::create_pipeline(
+                device,
+                &self.sc_desc,
+                &self.vs_module,
+                &self.fs_module,
+                &self.pipeline_layout,
+                self.sample_count,
+            );
+            self.multisampled_framebuffer =
+                Example::create_multisampled_framebuffer(device, &self.sc_desc, self.sample_count);
             self.rebuild_pipeline = false;
         }
 
-        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
         {
             let rpass_color_attachment = if self.sample_count == 1 {
                 wgpu::RenderPassColorAttachmentDescriptor {
@@ -217,7 +263,7 @@ impl framework::Example for Example {
             });
             rpass.set_pipeline(&self.pipeline);
             rpass.set_vertex_buffers(0, &[(&self.vertex_buffer, 0)]);
-            rpass.draw(0..self.vertex_count, 0..1);
+            rpass.draw(0 .. self.vertex_count, 0 .. 1);
         }
 
         encoder.finish()

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -114,11 +114,17 @@ impl Light {
             far: self.depth.end,
         };
         let mx_correction = framework::OPENGL_TO_WGPU_MATRIX;
-        let mx_view_proj = mx_correction * cgmath::Matrix4::from(projection.to_perspective()) * mx_view;
+        let mx_view_proj =
+            mx_correction * cgmath::Matrix4::from(projection.to_perspective()) * mx_view;
         LightRaw {
             proj: *mx_view_proj.as_ref(),
             pos: [self.pos.x, self.pos.y, self.pos.z, 1.0],
-            color: [self.color.r as f32, self.color.g as f32, self.color.b as f32, 1.0],
+            color: [
+                self.color.r as f32,
+                self.color.g as f32,
+                self.color.b as f32,
+                1.0,
+            ],
         }
     }
 }
@@ -181,7 +187,10 @@ impl Example {
 }
 
 impl framework::Example for Example {
-    fn init(sc_desc: &wgpu::SwapChainDescriptor, device: &wgpu::Device) -> (Self, Option<wgpu::CommandBuffer>) {
+    fn init(
+        sc_desc: &wgpu::SwapChainDescriptor,
+        device: &wgpu::Device,
+    ) -> (Self, Option<wgpu::CommandBuffer>) {
         // Create the vertex and index buffers
         let vertex_size = mem::size_of::<Vertex>();
         let (cube_vertex_data, cube_index_data) = create_cube();
@@ -212,15 +221,14 @@ impl framework::Example for Example {
             usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
         });
 
-        let local_bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            bindings: &[
-                wgpu::BindGroupLayoutBinding {
+        let local_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                bindings: &[wgpu::BindGroupLayoutBinding {
                     binding: 0,
                     visibility: wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::UniformBuffer { dynamic: false },
-                },
-            ],
-        });
+                }],
+            });
 
         let mut entities = vec![{
             use cgmath::SquareMatrix;
@@ -404,15 +412,14 @@ impl framework::Example for Example {
 
         let shadow_pass = {
             // Create pipeline layout
-            let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                bindings: &[
-                    wgpu::BindGroupLayoutBinding {
+            let bind_group_layout =
+                device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    bindings: &[wgpu::BindGroupLayoutBinding {
                         binding: 0, // global
                         visibility: wgpu::ShaderStage::VERTEX,
                         ty: wgpu::BindingType::UniformBuffer { dynamic: false },
-                    },
-                ],
-            });
+                    }],
+                });
             let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 bind_group_layouts: &[&bind_group_layout, &local_bind_group_layout],
             });
@@ -493,16 +500,12 @@ impl framework::Example for Example {
                         wgpu::BindGroupLayoutBinding {
                             binding: 0, // global
                             visibility: wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
-                            ty: wgpu::BindingType::UniformBuffer {
-                                dynamic: false,
-                            },
+                            ty: wgpu::BindingType::UniformBuffer { dynamic: false },
                         },
                         wgpu::BindGroupLayoutBinding {
                             binding: 1, // lights
                             visibility: wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
-                            ty: wgpu::BindingType::UniformBuffer {
-                                dynamic: false,
-                            },
+                            ty: wgpu::BindingType::UniformBuffer { dynamic: false },
                         },
                         wgpu::BindGroupLayoutBinding {
                             binding: 2,
@@ -530,10 +533,7 @@ impl framework::Example for Example {
             };
             let uniform_size = mem::size_of::<ForwardUniforms>() as wgpu::BufferAddress;
             let uniform_buf = device
-                .create_buffer_mapped(
-                    1,
-                    wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
-                )
+                .create_buffer_mapped(1, wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST)
                 .fill_from_slice(&[forward_uniforms]);
 
             // Create bind group
@@ -652,7 +652,11 @@ impl framework::Example for Example {
         //empty
     }
 
-    fn resize(&mut self, sc_desc: &wgpu::SwapChainDescriptor, device: &wgpu::Device) -> Option<wgpu::CommandBuffer> {
+    fn resize(
+        &mut self,
+        sc_desc: &wgpu::SwapChainDescriptor,
+        device: &wgpu::Device,
+    ) -> Option<wgpu::CommandBuffer> {
         let command_buf = {
             let mx_total = Self::generate_matrix(sc_desc.width as f32 / sc_desc.height as f32);
             let mx_ref: &[f32; 16] = mx_total.as_ref();
@@ -684,7 +688,11 @@ impl framework::Example for Example {
         Some(command_buf)
     }
 
-    fn render(&mut self, frame: &wgpu::SwapChainOutput, device: &wgpu::Device) -> wgpu::CommandBuffer {
+    fn render(
+        &mut self,
+        frame: &wgpu::SwapChainOutput,
+        device: &wgpu::Device,
+    ) -> wgpu::CommandBuffer {
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
 

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -172,7 +172,9 @@ impl framework::Example for Skybox {
         for (i, image) in faces.iter().enumerate() {
             log::debug!(
                 "Copying skybox image {} of size {},{} to gpu",
-                i, image_width, image_height,
+                i,
+                image_width,
+                image_height,
             );
             let image_buf = device
                 .create_buffer_mapped(image.len(), wgpu::BufferUsage::COPY_SRC)
@@ -215,7 +217,7 @@ impl framework::Example for Skybox {
                     binding: 0,
                     resource: wgpu::BindingResource::Buffer {
                         buffer: &uniform_buf,
-                        range: 0..uniform_buf_size as wgpu::BufferAddress,
+                        range: 0 .. uniform_buf_size as wgpu::BufferAddress,
                     },
                 },
                 wgpu::Binding {
@@ -306,7 +308,7 @@ impl framework::Example for Skybox {
 
             rpass.set_pipeline(&self.pipeline);
             rpass.set_bind_group(0, &self.bind_group, &[]);
-            rpass.draw(0..3 as u32, 0..1);
+            rpass.draw(0 .. 3 as u32, 0 .. 1);
         }
         init_encoder.finish()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -494,10 +494,7 @@ pub struct CreateBufferMapped<'a, T> {
     pub data: &'a mut [T],
 }
 
-impl<'a, T> CreateBufferMapped<'a, T>
-where
-    T: Copy,
-{
+impl<'a, T> CreateBufferMapped<'a, T> {
     /// Copies a slice into the mapped buffer and unmaps it, returning a [`Buffer`].
     ///
     /// `slice` and `self.data` must have the same length.
@@ -505,7 +502,10 @@ where
     /// # Panics
     ///
     /// Panics if the slices have different lengths.
-    pub fn fill_from_slice(self, slice: &[T]) -> Buffer {
+    pub fn fill_from_slice(self, slice: &[T]) -> Buffer
+    where
+        T: Copy,
+    {
         self.data.copy_from_slice(slice);
         self.finish()
     }
@@ -794,10 +794,7 @@ impl Device {
         &'a self,
         count: usize,
         usage: BufferUsage,
-    ) -> CreateBufferMapped<'a, T>
-    where
-        T: 'static + Copy,
-    {
+    ) -> CreateBufferMapped<'a, T> {
         let type_size = std::mem::size_of::<T>() as BufferAddress;
         assert_ne!(type_size, 0);
 
@@ -888,8 +885,8 @@ where
 impl Buffer {
     pub fn map_read_async<T, F>(&self, start: BufferAddress, size: BufferAddress, callback: F)
     where
-        T: 'static + FromBytes,
-        F: FnOnce(BufferMapAsyncResult<&[T]>) + 'static,
+        T: FromBytes,
+        F: FnOnce(BufferMapAsyncResult<&[T]>),
     {
         extern "C" fn buffer_map_read_callback_wrapper<T, F>(
             status: wgn::BufferMapAsyncStatus,
@@ -934,8 +931,8 @@ impl Buffer {
 
     pub fn map_write_async<T, F>(&self, start: BufferAddress, size: BufferAddress, callback: F)
     where
-        T: 'static + AsBytes + FromBytes,
-        F: FnOnce(BufferMapAsyncResult<&mut [T]>) + 'static,
+        T: AsBytes + FromBytes,
+        F: FnOnce(BufferMapAsyncResult<&mut [T]>),
     {
         extern "C" fn buffer_map_write_callback_wrapper<T, F>(
             status: wgn::BufferMapAsyncStatus,

--- a/tests/multithreaded_compute.rs
+++ b/tests/multithreaded_compute.rs
@@ -28,7 +28,8 @@ fn multithreaded_compute() {
             });
 
             let cs = include_bytes!("../examples/hello-compute/shader.comp.spv");
-            let cs_module = device.create_shader_module(&wgpu::read_spirv(std::io::Cursor::new(&cs[..])).unwrap());
+            let cs_module = device
+                .create_shader_module(&wgpu::read_spirv(std::io::Cursor::new(&cs[..])).unwrap());
 
             let staging_buffer = device
                 .create_buffer_mapped(
@@ -48,16 +49,14 @@ fn multithreaded_compute() {
 
             let bind_group_layout =
                 device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                    bindings: &[
-                        wgpu::BindGroupLayoutBinding {
-                            binding: 0,
-                            visibility: wgpu::ShaderStage::COMPUTE,
-                            ty: wgpu::BindingType::StorageBuffer {
-                                dynamic: false,
-                                readonly: false,
-                            },
+                    bindings: &[wgpu::BindGroupLayoutBinding {
+                        binding: 0,
+                        visibility: wgpu::ShaderStage::COMPUTE,
+                        ty: wgpu::BindingType::StorageBuffer {
+                            dynamic: false,
+                            readonly: false,
                         },
-                    ],
+                    }],
                 });
 
             let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {


### PR DESCRIPTION
Also removes unnecessary `'static` lifetimes. LMK if you would like me to undo 62bbe5f (`cargo fmt`).