### PR TITLE
Small updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Cargo.lock
 
 # Other
 .DS_Store
+
+# Output from capture example
+red.png

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-sudo: false
+cache: cargo
 os:
   - linux
   - osx


### PR DESCRIPTION
Enable Travis CI cache, disable [deprecated container-based builds](https://docs.travis-ci.com/user/reference/trusty/#container-based-infrastructure), and add `red.png` to `.gitignore` (output from `cargo run --example capture`).