### PR TITLE
Change Queue::submit to take &self

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ rev = "b51053dc2dc3bbe9b2ba050fde42eeb6405fe092"
 
 [dependencies]
 arrayvec = "0.5"
+smallvec = "1"
 raw-window-handle = "0.3"
 
 [dev-dependencies]

--- a/examples/capture/main.rs
+++ b/examples/capture/main.rs
@@ -15,7 +15,7 @@ async fn run() {
     )
     .unwrap();
 
-    let (device, mut queue) = adapter.request_device(&wgpu::DeviceDescriptor {
+    let (device, queue) = adapter.request_device(&wgpu::DeviceDescriptor {
         extensions: wgpu::Extensions {
             anisotropic_filtering: false,
         },

--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -102,7 +102,7 @@ pub fn run<E: Example>(title: &str) {
     )
     .unwrap();
 
-    let (device, mut queue) = adapter.request_device(&wgpu::DeviceDescriptor {
+    let (device, queue) = adapter.request_device(&wgpu::DeviceDescriptor {
         extensions: wgpu::Extensions {
             anisotropic_filtering: false,
         },

--- a/examples/hello-compute/main.rs
+++ b/examples/hello-compute/main.rs
@@ -24,7 +24,7 @@ async fn run() {
     )
     .unwrap();
 
-    let (device, mut queue) = adapter.request_device(&wgpu::DeviceDescriptor {
+    let (device, queue) = adapter.request_device(&wgpu::DeviceDescriptor {
         extensions: wgpu::Extensions {
             anisotropic_filtering: false,
         },

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -44,7 +44,7 @@ fn main() {
     )
     .unwrap();
 
-    let (device, mut queue) = adapter.request_device(&wgpu::DeviceDescriptor {
+    let (device, queue) = adapter.request_device(&wgpu::DeviceDescriptor {
         extensions: wgpu::Extensions {
             anisotropic_filtering: false,
         },


### PR DESCRIPTION
This small change allows multiple threads to submit buffers slightly more efficiently, by being able to do it concurrently without a lock on Queue.

In practice currently `Queue::submit` does a lot of locking internally for most of the function's duration, so it's only a small performance win right now, but it opens up the road for more improvements.