### PR TITLE
Update readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ## wgpu-rs
 [![Build Status](https://travis-ci.org/gfx-rs/wgpu-rs.svg)](https://travis-ci.org/gfx-rs/wgpu-rs)
 [![Crates.io](https://img.shields.io/crates/v/wgpu.svg)](https://crates.io/crates/wgpu)
-[![Gitter](https://badges.gitter.im/gfx-rs/webgpu.svg)](https://gitter.im/gfx-rs/webgpu)
+[![Docs.rs](https://docs.rs/wgpu/badge.svg)](https://docs.rs/wgpu)
+[![Matrix](https://img.shields.io/matrix/wgpu:matrix.org)](https://matrix.to/#/#wgpu:matrix.org)
 
 This is an idiomatic Rust wrapper over [wgpu-core](https://github.com/gfx-rs/wgpu). It's designed to be suitable for general purpose graphics and computation needs of Rust community. It currently only works for the native platform, in the future aims to support WASM/Emscripten platforms as well.
 


### PR DESCRIPTION
Adds docs.rs badge link and replaces gitter badge with a matrix badge.

Looks like the the matrix room needs to be more public or else i've somehow messed up the matrix room name in the badge url.