### PR TITLE
Expose `enumerate_adapters`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,14 +27,14 @@ vulkan = ["wgn/vulkan-portability"]
 package = "wgpu-native"
 version = "0.4"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "f2323f2b23b7dbe060d324266cf6c1c864152e91"
+rev = "429ca1d4460becd20d771f67024878948b60454b"
 #path = "../wgpu/wgpu-native"
 
 [dependencies.wgc]
 package = "wgpu-core"
 version = "0.1"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "f2323f2b23b7dbe060d324266cf6c1c864152e91"
+rev = "429ca1d4460becd20d771f67024878948b60454b"
 #path = "../wgpu/wgpu-core"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,6 +522,14 @@ impl Surface {
 }
 
 impl Adapter {
+    /// Retrieves all available [`Adapter`]s that match the given backends.
+    pub fn enumerate(backends: BackendBit) -> Vec<Self> {
+        wgn::wgpu_enumerate_adapters(backends)
+            .into_iter()
+            .map(|id| Adapter { id })
+            .collect()
+    }
+
     /// Retrieves an [`Adapter`] which matches the given options.
     ///
     /// Some options are "soft", so treated as non-mandatory. Others are "hard".


### PR DESCRIPTION
Depends on gfx-rs/wgpu#505.

Use case was to give end user the ability to choose which GPU to use for an application.