### PR TITLE
Explicitly declare vertex attribute descriptors in cube example

### DIFF
--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -3,8 +3,6 @@ mod framework;
 
 use zerocopy::{AsBytes, FromBytes};
 
-use wgpu::vertex_attr_array;
-
 #[repr(C)]
 #[derive(Clone, Copy, AsBytes, FromBytes)]
 struct Vertex {
@@ -277,7 +275,18 @@ impl framework::Example for Example {
             vertex_buffers: &[wgpu::VertexBufferDescriptor {
                 stride: vertex_size as wgpu::BufferAddress,
                 step_mode: wgpu::InputStepMode::Vertex,
-                attributes: &vertex_attr_array![0 => Float4, 1 => Float2],
+                attributes: &[
+                    wgpu::VertexAttributeDescriptor {
+                        format: wgpu::VertexFormat::Float4,
+                        offset: 0,
+                        shader_location: 0,
+                    },
+                    wgpu::VertexAttributeDescriptor {
+                        format: wgpu::VertexFormat::Float2,
+                        offset: 4 * 4,
+                        shader_location: 1,
+                    },
+                ],
             }],
             sample_count: 1,
             sample_mask: !0,


### PR DESCRIPTION
The new `vertex_attr_array!` macro is pretty wonderful, but it's nice to have at least one reference example of how `VertexAttributeDescriptor`s are constructed. 