### PR TITLE
Derive `Hash` and `PartialEq` for unique identifier wrapper types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ struct Temp {
 ///
 /// An `Adapter` can be used to open a connection to the corresponding device on the host system,
 /// yielding a [`Device`] object.
-#[derive(Debug)]
+#[derive(Debug, Hash, PartialEq)]
 pub struct Adapter {
     id: wgc::id::AdapterId,
 }
@@ -110,14 +110,14 @@ pub struct Device {
 }
 
 /// A handle to a GPU-accessible buffer.
-#[derive(Debug)]
+#[derive(Debug, Hash, PartialEq)]
 pub struct Buffer {
     id: wgc::id::BufferId,
     device_id: wgc::id::DeviceId,
 }
 
 /// A handle to a texture on the GPU.
-#[derive(Debug)]
+#[derive(Debug, Hash, PartialEq)]
 pub struct Texture {
     id: wgc::id::TextureId,
     owned: bool,
@@ -127,7 +127,7 @@ pub struct Texture {
 ///
 /// A `TextureView` object describes a texture and associated metadata needed by a
 /// [`RenderPipeline`] or [`BindGroup`].
-#[derive(Debug)]
+#[derive(Debug, Hash, PartialEq)]
 pub struct TextureView {
     id: wgc::id::TextureViewId,
     owned: bool,
@@ -138,7 +138,7 @@ pub struct TextureView {
 /// A `Sampler` object defines how a pipeline will sample from a [`TextureView`]. Samplers define
 /// image filters (including anisotropy) and address (wrapping) modes, among other things. See
 /// the documentation for [`SamplerDescriptor`] for more information.
-#[derive(Debug)]
+#[derive(Debug, Hash, PartialEq)]
 pub struct Sampler {
     id: wgc::id::SamplerId,
 }
@@ -147,7 +147,7 @@ pub struct Sampler {
 ///
 /// A `Surface` represents a platform-specific surface (e.g. a window) to which rendered images may
 /// be presented. A `Surface` may be created with [`Surface::create`].
-#[derive(Debug)]
+#[derive(Debug, Hash, PartialEq)]
 pub struct Surface {
     id: wgc::id::SurfaceId,
 }
@@ -156,7 +156,7 @@ pub struct Surface {
 ///
 /// A `SwapChain` represents the image or series of images that will be presented to a [`Surface`].
 /// A `SwapChain` may be created with [`Device::create_swap_chain`].
-#[derive(Debug)]
+#[derive(Debug, Hash, PartialEq)]
 pub struct SwapChain {
     id: wgc::id::SwapChainId,
 }
@@ -167,7 +167,7 @@ pub struct SwapChain {
 /// create a [`BindGroupDescriptor`] object, which in turn can be used to create a [`BindGroup`]
 /// object with [`Device::create_bind_group`]. A series of `BindGroupLayout`s can also be used to
 /// create a [`PipelineLayoutDescriptor`], which can be used to create a [`PipelineLayout`].
-#[derive(Debug)]
+#[derive(Debug, Hash, PartialEq)]
 pub struct BindGroupLayout {
     id: wgc::id::BindGroupLayoutId,
 }
@@ -178,7 +178,7 @@ pub struct BindGroupLayout {
 /// [`BindGroupLayout`]. It can be created with [`Device::create_bind_group`]. A `BindGroup` can
 /// be bound to a particular [`RenderPass`] with [`RenderPass::set_bind_group`], or to a
 /// [`ComputePass`] with [`ComputePass::set_bind_group`].
-#[derive(Debug)]
+#[derive(Debug, Hash, PartialEq)]
 pub struct BindGroup {
     id: wgc::id::BindGroupId,
 }
@@ -194,7 +194,7 @@ impl Drop for BindGroup {
 /// A `ShaderModule` represents a compiled shader module on the GPU. It can be created by passing
 /// valid SPIR-V source code to [`Device::create_shader_module`]. Shader modules are used to define
 /// programmable stages of a pipeline.
-#[derive(Debug)]
+#[derive(Debug, Hash, PartialEq)]
 pub struct ShaderModule {
     id: wgc::id::ShaderModuleId,
 }
@@ -202,7 +202,7 @@ pub struct ShaderModule {
 /// An opaque handle to a pipeline layout.
 ///
 /// A `PipelineLayout` object describes the available binding groups of a pipeline.
-#[derive(Debug)]
+#[derive(Debug, Hash, PartialEq)]
 pub struct PipelineLayout {
     id: wgc::id::PipelineLayoutId,
 }
@@ -211,13 +211,13 @@ pub struct PipelineLayout {
 ///
 /// A `RenderPipeline` object represents a graphics pipeline and its stages, bindings, vertex
 /// buffers and targets. A `RenderPipeline` may be created with [`Device::create_render_pipeline`].
-#[derive(Debug)]
+#[derive(Debug, Hash, PartialEq)]
 pub struct RenderPipeline {
     id: wgc::id::RenderPipelineId,
 }
 
 /// A handle to a compute pipeline.
-#[derive(Debug)]
+#[derive(Debug, Hash, PartialEq)]
 pub struct ComputePipeline {
     id: wgc::id::ComputePipelineId,
 }
@@ -227,7 +227,7 @@ pub struct ComputePipeline {
 /// A `CommandBuffer` represents a complete sequence of commands that may be submitted to a command
 /// queue with [`Queue::submit`]. A `CommandBuffer` is obtained by recording a series of commands to
 /// a [`CommandEncoder`] and then calling [`CommandEncoder::finish`].
-#[derive(Debug)]
+#[derive(Debug, Hash, PartialEq)]
 pub struct CommandBuffer {
     id: wgc::id::CommandBufferId,
 }
@@ -264,7 +264,7 @@ pub struct ComputePass<'a> {
 /// A handle to a command queue on a device.
 ///
 /// A `Queue` executes recorded [`CommandBuffer`] objects.
-#[derive(Debug)]
+#[derive(Debug, Hash, PartialEq)]
 pub struct Queue {
     id: wgc::id::QueueId,
 }


### PR DESCRIPTION
This is particularly useful downstream for distinguishing between
instances of these types.

I was unsure about `Device` as I noticed it has a `Temp` field that
looks like it might eventually store some non-PartialEq/Hash-friendly
fields.

Let me know if you'd like me to add a derive for `Device` or if there
are any issues with those I have updated.