### PR TITLE
Improve BufferCopyView documentation

### DIFF
--- a/examples/capture/main.rs
+++ b/examples/capture/main.rs
@@ -77,7 +77,7 @@ async fn run() {
                 buffer: &output_buffer,
                 offset: 0,
                 bytes_per_row: size_of::<u32>() as u32 * size,
-                rows_per_image: size,
+                rows_per_image: 0,
             },
             texture_extent,
         );

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -180,7 +180,7 @@ impl framework::Example for Example {
                 buffer: &temp_buf,
                 offset: 0,
                 bytes_per_row: 4 * size,
-                rows_per_image: size,
+                rows_per_image: 0,
             },
             wgpu::TextureCopyView {
                 texture: &texture,

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -268,7 +268,7 @@ impl framework::Example for Example {
                 buffer: &temp_buf,
                 offset: 0,
                 bytes_per_row: 4 * size,
-                rows_per_image: size,
+                rows_per_image: 0,
             },
             wgpu::TextureCopyView {
                 texture: &texture,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,13 +408,16 @@ pub struct BufferCopyView<'a> {
     /// The buffer to be copied to or from.
     pub buffer: &'a Buffer,
 
-    /// The offset in bytes from the start of the buffer. This must be aligned to 512 bytes.
+    /// The offset in bytes from the start of the buffer.
+    /// In the future this must be aligned to 512 bytes, however the requirement is currently unimplemented.
     pub offset: BufferAddress,
 
-    /// The size in bytes of a single row of the texture. This must be a multiple of 256 bytes.
+    /// The size in bytes of a single row of the texture.
+    /// In the future this must be a multiple of 256 bytes, however the requirement is currently unimplemented.
     pub bytes_per_row: u32,
 
     /// The height in texels of the imaginary texture view overlaid on the buffer.
+    /// Must be zero for copies where `copy_size.depth == 1`.
     pub rows_per_image: u32,
 }
 


### PR DESCRIPTION
groves suggested that the alignment/multiple requirements are not implemented yet.
So I changed the documentation to reflect that.
Ideally we would change the examples to demonstrate how to work around this requirement, but I think its best to wait until we know for certain that this IS a requirement, currently the WebGPU spec does not have this as a requirement.

Additionally it seems like every example except for the skybox example failed to follow this part of the WebGPU spec.
"Note: rowsPerImage must be zero for copies with a copySize.depth of 1, and must be greater than zero otherwise."
So I fixed those examples and documented the requirement on the field.