### PR TITLE
Rewrite GpuFuture to avoid blocking and to use less space

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ rev = "08e8d406c175579da5ef18c1abf4d6c00e2a9726"
 arrayvec = "0.5"
 smallvec = "1"
 raw-window-handle = "0.3"
+parking_lot = "0.10"
 
 [dev-dependencies]
 cgmath = "0.17"

--- a/examples/capture/main.rs
+++ b/examples/capture/main.rs
@@ -5,8 +5,6 @@ use std::fs::File;
 use std::mem::size_of;
 
 async fn run() {
-    env_logger::init();
-
     let adapter = wgpu::Adapter::request(
         &wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::Default,
@@ -87,8 +85,16 @@ async fn run() {
 
     queue.submit(&[command_buffer]);
 
+    // Note that we're not calling `.await` here.
+    let buffer_future = output_buffer.map_read(0, (size * size) as u64 * size_of::<u32>() as u64);
+
+    // Poll the device in a blocking manner so that our future resolves.
+    // In an actual application, `device.poll(...)` should
+    // be called in an event loop or on another thread.
+    device.poll(wgpu::Maintain::Wait);
+
     // Write the buffer as a PNG
-    if let Ok(mapping) = output_buffer.map_read(0u64, (size * size) as u64 * size_of::<u32>() as u64).await {
+    if let Ok(mapping) = buffer_future.await {
         let mut png_encoder = png::Encoder::new(File::create("red.png").unwrap(), size, size);
         png_encoder.set_depth(png::BitDepth::Eight);
         png_encoder.set_color(png::ColorType::RGBA);
@@ -98,11 +104,10 @@ async fn run() {
             .write_image_data(mapping.as_slice())
             .unwrap();
     }
-
-    // The device will be polled when it is dropped but we can also poll it explicitly
-    device.poll(true);
 }
 
 fn main() {
+    env_logger::init();
+
     futures::executor::block_on(run());
 }


### PR DESCRIPTION
Since `GpuFuture` doesn't blocking wait for the mapping to resolve anymore, we need to poll the device for it to actually work. ~~I haven't added that to the `hello-compute` example, so it doesn't work anymore.~~