### PR TITLE
Update Zerocopy to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ log = "0.4"
 png = "0.15"
 winit = "0.22"
 rand = "0.7.2"
-zerocopy = "0.2"
+zerocopy = "0.3"
 futures = "0.3"
 
 #[patch."https://github.com/gfx-rs/wgpu"]


### PR DESCRIPTION
In an effort to eliminate duplicate dependencies, especially on the proc-macro/syn stack, this updates zerocopy 0.2 (using syn 0.6) to zerocopy 0.3 (using syn 1). There appears to be no real api changes based on my skimming of the docs. Things compile on my windows machine, and hopefully it will pass on mac and linux.