### PR TITLE
Specify expected structure for draw_indirect and draw_indexed_indirect

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1505,6 +1505,18 @@ impl<'a> RenderPass<'a> {
     /// Draws primitives from the active vertex buffer(s) based on the contents of the `indirect_buffer`.
     ///
     /// The active vertex buffers can be set with [`RenderPass::set_vertex_buffer`].
+    /// 
+    /// The structure expected in `indirect_buffer` is the following:
+    /// 
+    /// ```rust
+    /// #[repr(C)]
+    /// struct DrawIndirect {
+    ///     vertex_count: u32,
+    ///     instance_count: u32,
+    ///     first_vertex: u32,
+    ///     base_instance: u32,
+    /// }
+    /// ```
     pub fn draw_indirect(&mut self, indirect_buffer: &'a Buffer, indirect_offset: BufferAddress) {
         unsafe {
             wgn::wgpu_render_pass_draw_indirect(
@@ -1520,6 +1532,19 @@ impl<'a> RenderPass<'a> {
     ///
     /// The active index buffer can be set with [`RenderPass::set_index_buffer`], while the active
     /// vertex buffers can be set with [`RenderPass::set_vertex_buffer`].
+    /// 
+    /// The structure expected in `indirect_buffer` is the following:
+    /// 
+    /// ```rust
+    /// #[repr(C)]
+    /// struct DrawIndexedIndirect {
+    ///     vertex_count: u32,
+    ///     instance_count: u32,
+    ///     first_index: u32,
+    ///     base_vertex: u32,
+    ///     base_instance: u32,
+    /// }
+    /// ```
     pub fn draw_indexed_indirect(
         &mut self,
         indirect_buffer: &'a Buffer,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1511,10 +1511,10 @@ impl<'a> RenderPass<'a> {
     /// ```rust
     /// #[repr(C)]
     /// struct DrawIndirect {
-    ///     vertex_count: u32,
-    ///     instance_count: u32,
-    ///     first_vertex: u32,
-    ///     base_instance: u32,
+    ///     vertex_count: u32, // The number of vertices to draw.
+    ///     instance_count: u32, // The number of instances to draw.
+    ///     base_vertex: u32, // The Index of the first vertex to draw.
+    ///     base_instance: u32, // The instance ID of the first instance to draw.
     /// }
     /// ```
     pub fn draw_indirect(&mut self, indirect_buffer: &'a Buffer, indirect_offset: BufferAddress) {
@@ -1538,11 +1538,11 @@ impl<'a> RenderPass<'a> {
     /// ```rust
     /// #[repr(C)]
     /// struct DrawIndexedIndirect {
-    ///     vertex_count: u32,
-    ///     instance_count: u32,
-    ///     first_index: u32,
-    ///     base_vertex: u32,
-    ///     base_instance: u32,
+    ///     vertex_count: u32, // The number of vertices to draw.
+    ///     instance_count: u32, // The number of instances to draw.
+    ///     base_index: u32, // The base index within the index buffer.
+    ///     vertex_offset: i32, // The value added to the vertex index before indexing into the vertex buffer.
+    ///     base_instance: u32, // The instance ID of the first instance to draw.
     /// }
     /// ```
     pub fn draw_indexed_indirect(


### PR DESCRIPTION
~~Based on https://www.khronos.org/opengl/wiki/Vertex_Rendering#Indirect_rendering.~~ Turns out the opengl docs are wrong. Based on https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDrawIndirectCommand.html.