### PR TITLE
Remove zerocopy and replace with bytemuck.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ log = "0.4"
 png = "0.15"
 winit = "0.22"
 rand = "0.7.2"
-zerocopy = "0.3"
+bytemuck = "1"
 futures = "0.3"
 
 [[example]]

--- a/examples/boids/main.rs
+++ b/examples/boids/main.rs
@@ -7,7 +7,6 @@ extern crate rand;
 mod framework;
 
 use std::fmt::Write;
-use zerocopy::AsBytes;
 
 use wgpu::vertex_attr_array;
 
@@ -165,7 +164,7 @@ impl framework::Example for Example {
 
         let vertex_buffer_data = [-0.01f32, -0.02, 0.01, -0.02, 0.00, 0.02];
         let vertices_buffer = device.create_buffer_with_data(
-            vertex_buffer_data.as_bytes(),
+            bytemuck::bytes_of(&vertex_buffer_data),
             wgpu::BufferUsage::VERTEX | wgpu::BufferUsage::COPY_DST,
         );
 
@@ -182,7 +181,7 @@ impl framework::Example for Example {
         ]
         .to_vec();
         let sim_param_buffer = device.create_buffer_with_data(
-            sim_param_data.as_bytes(),
+            bytemuck::cast_slice(&sim_param_data),
             wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
         );
 
@@ -204,7 +203,7 @@ impl framework::Example for Example {
         let mut particle_bind_groups = Vec::<wgpu::BindGroup>::new();
         for _i in 0..2 {
             particle_buffers.push(device.create_buffer_with_data(
-                initial_particle_data.as_bytes(),
+                bytemuck::cast_slice(&initial_particle_data),
                 wgpu::BufferUsage::VERTEX
                     | wgpu::BufferUsage::STORAGE
                     | wgpu::BufferUsage::COPY_DST,

--- a/examples/hello-compute/main.rs
+++ b/examples/hello-compute/main.rs
@@ -1,5 +1,4 @@
 use std::{convert::TryInto as _, str::FromStr};
-use zerocopy::AsBytes as _;
 
 async fn run() {
     let numbers = if std::env::args().len() == 1 {
@@ -45,7 +44,7 @@ async fn execute_gpu(numbers: Vec<u32>) -> Vec<u32> {
         device.create_shader_module(&wgpu::read_spirv(std::io::Cursor::new(&cs[..])).unwrap());
 
     let staging_buffer = device.create_buffer_with_data(
-        numbers.as_slice().as_bytes(),
+        bytemuck::cast_slice(&numbers),
         wgpu::BufferUsage::MAP_READ | wgpu::BufferUsage::COPY_DST | wgpu::BufferUsage::COPY_SRC,
     );
 

--- a/examples/msaa-line/main.rs
+++ b/examples/msaa-line/main.rs
@@ -10,16 +10,19 @@
 #[path = "../framework.rs"]
 mod framework;
 
-use zerocopy::{AsBytes, FromBytes};
+use bytemuck::{Pod, Zeroable};
 
 use wgpu::vertex_attr_array;
 
 #[repr(C)]
-#[derive(Clone, Copy, AsBytes, FromBytes)]
+#[derive(Clone, Copy)]
 struct Vertex {
     _pos: [f32; 2],
     _color: [f32; 4],
 }
+
+unsafe impl Pod for Vertex {}
+unsafe impl Zeroable for Vertex {}
 
 struct Example {
     vs_module: wgpu::ShaderModule,
@@ -157,8 +160,10 @@ impl framework::Example for Example {
             });
         }
 
-        let vertex_buffer =
-            device.create_buffer_with_data(vertex_data.as_bytes(), wgpu::BufferUsage::VERTEX);
+        let vertex_buffer = device.create_buffer_with_data(
+            bytemuck::cast_slice(&vertex_data),
+            wgpu::BufferUsage::VERTEX,
+        );
         let vertex_count = vertex_data.len() as u32;
 
         let this = Example {

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -1,8 +1,6 @@
 #[path = "../framework.rs"]
 mod framework;
 
-use zerocopy::AsBytes as _;
-
 const SKYBOX_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
 
 type Uniform = cgmath::Matrix4<f32>;
@@ -45,7 +43,7 @@ fn buffer_from_uniforms(
             .data
             .chunks_exact_mut(std::mem::size_of::<Uniform>()),
     ) {
-        slot.copy_from_slice(AsRef::<[[f32; 4]; 4]>::as_ref(u).as_bytes());
+        slot.copy_from_slice(bytemuck::cast_slice(AsRef::<[[f32; 4]; 4]>::as_ref(u)));
     }
     uniform_buf.finish()
 }
@@ -280,8 +278,8 @@ impl framework::Example for Skybox {
         let mx_total = uniforms[0] * uniforms[1];
         let mx_ref: &[f32; 16] = mx_total.as_ref();
 
-        let temp_buf =
-            device.create_buffer_with_data(mx_ref.as_bytes(), wgpu::BufferUsage::COPY_SRC);
+        let temp_buf = device
+            .create_buffer_with_data(bytemuck::cast_slice(mx_ref), wgpu::BufferUsage::COPY_SRC);
 
         let mut init_encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1443,9 +1443,9 @@ impl<'a> RenderPass<'a> {
     /// Draws primitives from the active vertex buffer(s) based on the contents of the `indirect_buffer`.
     ///
     /// The active vertex buffers can be set with [`RenderPass::set_vertex_buffer`].
-    /// 
+    ///
     /// The structure expected in `indirect_buffer` is the following:
-    /// 
+    ///
     /// ```rust
     /// #[repr(C)]
     /// struct DrawIndirect {
@@ -1470,9 +1470,9 @@ impl<'a> RenderPass<'a> {
     ///
     /// The active index buffer can be set with [`RenderPass::set_index_buffer`], while the active
     /// vertex buffers can be set with [`RenderPass::set_vertex_buffer`].
-    /// 
+    ///
     /// The structure expected in `indirect_buffer` is the following:
-    /// 
+    ///
     /// ```rust
     /// #[repr(C)]
     /// struct DrawIndexedIndirect {


### PR DESCRIPTION
fixes #146 

I've removed `zerocopy` from the examples and replaced it with `bytemuck`. I ran all of the examples/tests and everything ran great in vulkan on my windows box.