### PR TITLE
Use opaque texels in mipmap example

### DIFF
--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -52,7 +52,7 @@ fn create_texels(size: usize, cx: f32, cy: f32) -> Vec<u8> {
             iter::once(0xFF - (count * 2) as u8)
                 .chain(iter::once(0xFF - (count * 5) as u8))
                 .chain(iter::once(0xFF - (count * 13) as u8))
-                .chain(iter::once(1))
+                .chain(iter::once(std::u8::MAX))
         })
         .collect()
 }


### PR DESCRIPTION
This fixes rendering for the mipmap example in Nightly