### PR TITLE
Force the wasm32 types to match Send / Sync with the native types

### DIFF
--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -906,6 +906,12 @@ pub(crate) struct BufferWriteMappingDetail {
     size: usize,
 }
 
+// SAFETY: It is safe to implement Send for `BufferReadMappingDetail` and `BufferWriteMappingDetail`
+// because the only !Send field is `data`, and it is used similarly to `&[u8]` or `&mut [u8]`.
+
+unsafe impl Send for BufferReadMappingDetail {}
+unsafe impl Send for BufferWriteMappingDetail {}
+
 impl BufferWriteMappingDetail {
     pub(crate) fn as_slice(&mut self) -> &mut [u8] {
         unsafe { slice::from_raw_parts_mut(self.data as *mut u8, self.size) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,37 +84,38 @@ trait RenderPassInner<Ctx: Context> {
 }
 
 trait Context: Sized {
-    type AdapterId;
-    type DeviceId;
-    type QueueId;
-    type ShaderModuleId;
-    type BindGroupLayoutId;
-    type BindGroupId;
-    type TextureViewId;
-    type SamplerId;
-    type BufferId;
-    type TextureId;
-    type PipelineLayoutId;
-    type RenderPipelineId;
-    type ComputePipelineId;
+    type AdapterId: Send + Sync;
+    type DeviceId: Send + Sync;
+    type QueueId: Send + Sync;
+    type ShaderModuleId: Send + Sync;
+    type BindGroupLayoutId: Send + Sync;
+    type BindGroupId: Send + Sync;
+    type TextureViewId: Send + Sync;
+    type SamplerId: Send + Sync;
+    type BufferId: Send + Sync;
+    type TextureId: Send + Sync;
+    type PipelineLayoutId: Send + Sync;
+    type RenderPipelineId: Send + Sync;
+    type ComputePipelineId: Send + Sync;
     type CommandEncoderId;
     type ComputePassId: ComputePassInner<Self>;
-    type CommandBufferId;
-    type SurfaceId;
-    type SwapChainId;
+    type CommandBufferId: Send + Sync;
+    type SurfaceId: Send + Sync;
+    type SwapChainId: Send + Sync;
     type RenderPassId: RenderPassInner<Self>;
 
-    type CreateBufferMappedDetail;
-    type BufferReadMappingDetail;
-    type BufferWriteMappingDetail;
-    type SwapChainOutputDetail;
+    type CreateBufferMappedDetail: Send;
+    type BufferReadMappingDetail: Send;
+    type BufferWriteMappingDetail: Send;
+    type SwapChainOutputDetail: Send;
 
-    type RequestAdapterFuture: Future<Output = Option<Self::AdapterId>>;
-    type RequestDeviceFuture: Future<
-        Output = Result<(Self::DeviceId, Self::QueueId), RequestDeviceError>,
-    >;
-    type MapReadFuture: Future<Output = Result<Self::BufferReadMappingDetail, BufferAsyncError>>;
-    type MapWriteFuture: Future<Output = Result<Self::BufferWriteMappingDetail, BufferAsyncError>>;
+    type RequestAdapterFuture: Future<Output = Option<Self::AdapterId>> + Send;
+    type RequestDeviceFuture: Future<Output = Result<(Self::DeviceId, Self::QueueId), RequestDeviceError>>
+        + Send;
+    type MapReadFuture: Future<Output = Result<Self::BufferReadMappingDetail, BufferAsyncError>>
+        + Send;
+    type MapWriteFuture: Future<Output = Result<Self::BufferWriteMappingDetail, BufferAsyncError>>
+        + Send;
 
     fn init() -> Self;
     fn instance_create_surface(
@@ -940,7 +941,7 @@ impl Instance {
         &self,
         options: &RequestAdapterOptions<'_>,
         backends: BackendBit,
-    ) -> impl Future<Output = Option<Adapter>> {
+    ) -> impl Future<Output = Option<Adapter>> + Send {
         let context = Arc::clone(&self.context);
         self.context
             .instance_request_adapter(options, backends)
@@ -959,7 +960,7 @@ impl Adapter {
         &self,
         desc: &DeviceDescriptor,
         trace_path: Option<&std::path::Path>,
-    ) -> impl Future<Output = Result<(Device, Queue), RequestDeviceError>> {
+    ) -> impl Future<Output = Result<(Device, Queue), RequestDeviceError>> + Send {
         let context = Arc::clone(&self.context);
         Context::adapter_request_device(&*self.context, &self.id, desc, trace_path).map(|result| {
             result.map(|(device_id, queue_id)| {
@@ -1178,7 +1179,7 @@ impl Buffer {
         &self,
         start: BufferAddress,
         size: BufferAddress,
-    ) -> impl Future<Output = Result<BufferReadMapping, BufferAsyncError>> {
+    ) -> impl Future<Output = Result<BufferReadMapping, BufferAsyncError>> + Send {
         let context = Arc::clone(&self.context);
         self.context
             .buffer_map_read(&self.id, start, size)
@@ -1193,7 +1194,7 @@ impl Buffer {
         &self,
         start: BufferAddress,
         size: BufferAddress,
-    ) -> impl Future<Output = Result<BufferWriteMapping, BufferAsyncError>> {
+    ) -> impl Future<Output = Result<BufferWriteMapping, BufferAsyncError>> + Send {
         let context = Arc::clone(&self.context);
         self.context
             .buffer_map_write(&self.id, start, size)


### PR DESCRIPTION
This is potentially a controversial change so this is just a draft to discuss it.

Currently, when building wgpu on wasm32, none of the interface types are Send or Sync, whereas on any other platform they are generally Send and Sync and this can cause a lot of pain, especially in the presence of async.

This PR is the nuclear option: lie and forcibly declare nearly all interface types to be Send or Send + Sync.

I think I understand the situation with proposed wasm32 threading a bit better now, and as of right now at least with my current understanding, it seems to me unlikely that javascript values held by rust could *ever* be sent transparently to another worker.  The mechanism that rust apparently will use to implement transparent threading will be to use `SharedArrayBuffer` to share memory between multiple workers.  Javascript provides a way for certain (serializable) objects to be shared with with other workers through `worker.postMessage()`, so Javascript has *some* story for sending javascript values to other threads, but only plain rust values that exist solely in the `SharedArrayBuffer` memory are send-able under this scheme.  I've looked briefly through some of the wasm proposals like the interface types proposal, but I don't have a good sense if there's any proposed mechanism at all for interface types and threads to interact at all.

If that's true that's really unfortunate because it seems like any thread safe API shared by native and web is doomed to mismatch.  This is even more unfortunate because many of the webgpu types in the draft standard are marked as 'Serializable', meaning that they *are* actually safe to send to another worker via `postMessage`, but there does not appear to be a planned way for rust to do this transparently.

I definitely could be misunderstanding the situation though and even if I am understanding it, the situation may have since changed.  I also don't know the timing here, I don't know what the eventual timing of wasm32 threading support will be vs webgpu support and interface types support.  *Right now* this PR is almost certainly sound, but there's definitely a possible future where it becomes unsound, and even maybe a possible future where it becomes unsound but then could later be made sound again.