### PR TITLE
Disable fail fast on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-10.15, ubuntu-18.04, windows-2019]
         wasm: [true, false]


### PR DESCRIPTION
Without this GitHub cancels all in-progress jobs if any matrix job fails