### PR TITLE
Build and deploy examples in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  RUSTFLAGS: --cfg=web_sys_unstable_apis
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+      - name: Install Rust WASM toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+      - name: Build the examples
+        run: cargo build --release --target wasm32-unknown-unknown --examples
+      - name: Install wasm-bindgen-cli
+        run: cargo install wasm-bindgen-cli
+      - name: Generate JS bindings for the examples
+        run: |
+          for i in target/wasm32-unknown-unknown/release/examples/*.wasm;
+          do
+            wasm-bindgen --no-typescript --out-dir target/generated --web "$i";
+          done
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: target/generated
+          TARGET_FOLDER: examples


### PR DESCRIPTION
Adds a workflow to GH Actions to build and deploy the updated examples to the `ghpages` branch. Example of what it produces [on this branch](https://github.com/GabrielMajeri/wgpu-rs/tree/gh-pages).

Fixes #270.