### PR TITLE
Improve example friendliness: Don't busy-redraw in examples

### DIFF
--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -100,7 +100,6 @@ async fn run(event_loop: EventLoop<()>, window: Window, swapchain_format: wgpu::
 
         *control_flow = ControlFlow::Poll;
         match event {
-            Event::MainEventsCleared => window.request_redraw(),
             Event::WindowEvent {
                 event: WindowEvent::Resized(size),
                 ..


### PR DESCRIPTION
Looking around for solid Rust graphics libraries, I was a bit shocked when the `wgpu-rs` examples made my whole X desktop environment in Ubuntu laggy---maximizing/minimizing other windows or moving any of them had very noticeable latency when an example was running.

This almost turned me off, but after playing around I found that this was just because of the
```rust
match event {
            event::Event::MainEventsCleared => window.request_redraw(),
            ...
```
in all of the examples. Trying to add the least code possible I've replaced a `ControlFlow::Poll` with `ControlFlow::WaitUntil(...)` in the event loops and capped the redraws-per-second below 50, which completely solves this problem for me (plus the window resize response on the examples themselves are much improved, etc.).

I was just going for an unintrusive fix---this is by no means a perfect solution, but I think in the worst case it won't be any worse that what was there originally. Plus, I think it will make people like me who try to start by copying an example more likely to stick around in the short term.