### PR TITLE
Rename SwapChain::get_next_texture to SwapChain::get_next_frame, and return errors to the user.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,14 @@ vulkan = ["wgc/gfx-backend-vulkan"]
 package = "wgpu-core"
 version = "0.5"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "4e1d76013c0b272383400beba48dc306e1a350f6"
+rev = "a6d468086dc48683d0c97b9e3b63264ad67660da"
 features = ["raw-window-handle"]
 
 [dependencies.wgt]
 package = "wgpu-types"
 version = "0.5"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "4e1d76013c0b272383400beba48dc306e1a350f6"
+rev = "a6d468086dc48683d0c97b9e3b63264ad67660da"
 
 [dependencies]
 arrayvec = "0.5"

--- a/examples/boids/main.rs
+++ b/examples/boids/main.rs
@@ -259,7 +259,7 @@ impl framework::Example for Example {
     ///   a TriangleList draw call for all NUM_PARTICLES at 3 vertices each
     fn render(
         &mut self,
-        frame: &wgpu::SwapChainOutput,
+        frame: &wgpu::SwapChainTexture,
         device: &wgpu::Device,
         _queue: &wgpu::Queue,
     ) -> wgpu::CommandBuffer {

--- a/examples/capture/main.rs
+++ b/examples/capture/main.rs
@@ -95,7 +95,7 @@ async fn run() {
     queue.submit(Some(command_buffer));
 
     // Note that we're not calling `.await` here.
-    let buffer_future = output_buffer.map_read(0, (size * size) as u64 * size_of::<u32>() as u64);
+    let buffer_future = output_buffer.map_read(0, wgt::BufferSize::WHOLE);
 
     // Poll the device in a blocking manner so that our future resolves.
     // In an actual application, `device.poll(...)` should

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -319,7 +319,7 @@ impl framework::Example for Example {
 
     fn render(
         &mut self,
-        frame: &wgpu::SwapChainOutput,
+        frame: &wgpu::SwapChainTexture,
         device: &wgpu::Device,
         _queue: &wgpu::Queue,
     ) -> wgpu::CommandBuffer {

--- a/examples/hello-compute/main.rs
+++ b/examples/hello-compute/main.rs
@@ -111,7 +111,7 @@ async fn execute_gpu(numbers: Vec<u32>) -> Vec<u32> {
     queue.submit(Some(encoder.finish()));
 
     // Note that we're not calling `.await` here.
-    let buffer_future = staging_buffer.map_read(0, size);
+    let buffer_future = staging_buffer.map_read(0, wgt::BufferSize::WHOLE);
 
     // Poll the device in a blocking manner so that our future resolves.
     // In an actual application, `device.poll(...)` should

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -110,8 +110,9 @@ async fn run(event_loop: EventLoop<()>, window: Window, swapchain_format: wgpu::
             }
             Event::RedrawRequested(_) => {
                 let frame = swap_chain
-                    .get_next_texture()
-                    .expect("Timeout when acquiring next swap chain texture");
+                    .get_next_frame()
+                    .expect("Failed to acquire next swap chain texture")
+                    .output;
                 let mut encoder =
                     device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
                 {

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -412,7 +412,7 @@ impl framework::Example for Example {
 
     fn render(
         &mut self,
-        frame: &wgpu::SwapChainOutput,
+        frame: &wgpu::SwapChainTexture,
         device: &wgpu::Device,
         _queue: &wgpu::Queue,
     ) -> wgpu::CommandBuffer {

--- a/examples/msaa-line/main.rs
+++ b/examples/msaa-line/main.rs
@@ -218,7 +218,7 @@ impl framework::Example for Example {
 
     fn render(
         &mut self,
-        frame: &wgpu::SwapChainOutput,
+        frame: &wgpu::SwapChainTexture,
         device: &wgpu::Device,
         _queue: &wgpu::Queue,
     ) -> wgpu::CommandBuffer {

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -698,7 +698,7 @@ impl framework::Example for Example {
 
     fn render(
         &mut self,
-        frame: &wgpu::SwapChainOutput,
+        frame: &wgpu::SwapChainTexture,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
     ) -> wgpu::CommandBuffer {

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -261,7 +261,7 @@ impl framework::Example for Skybox {
 
     fn render(
         &mut self,
-        frame: &wgpu::SwapChainOutput,
+        frame: &wgpu::SwapChainTexture,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
     ) -> wgpu::CommandBuffer {

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -1,8 +1,8 @@
 use crate::{
     BindGroupDescriptor, BindGroupLayoutDescriptor, BindingResource, BindingType, BufferDescriptor,
     CommandEncoderDescriptor, ComputePipelineDescriptor, PipelineLayoutDescriptor,
-    ProgrammableStageDescriptor, RenderPipelineDescriptor, SamplerDescriptor, TextureDescriptor,
-    TextureViewDescriptor, TextureViewDimension,
+    ProgrammableStageDescriptor, RenderPipelineDescriptor, SamplerDescriptor, SwapChainStatus,
+    TextureDescriptor, TextureViewDescriptor, TextureViewDimension,
 };
 
 use futures::FutureExt;
@@ -107,20 +107,22 @@ impl crate::RenderPassInner<Context> for RenderPass {
         &mut self,
         buffer: &Sendable<web_sys::GpuBuffer>,
         offset: wgt::BufferAddress,
-        size: wgt::BufferAddress,
+        size: wgt::BufferSize,
     ) {
+        assert_ne!(size, wgt::BufferSize::WHOLE); //TODO
         self.0
-            .set_index_buffer_with_f64_and_f64(&buffer.0, offset as f64, size as f64);
+            .set_index_buffer_with_f64_and_f64(&buffer.0, offset as f64, size.0 as f64);
     }
     fn set_vertex_buffer(
         &mut self,
         slot: u32,
         buffer: &Sendable<web_sys::GpuBuffer>,
         offset: wgt::BufferAddress,
-        size: wgt::BufferAddress,
+        size: wgt::BufferSize,
     ) {
+        assert_ne!(size, wgt::BufferSize::WHOLE); //TODO
         self.0
-            .set_vertex_buffer_with_f64_and_f64(slot, &buffer.0, offset as f64, size as f64);
+            .set_vertex_buffer_with_f64_and_f64(slot, &buffer.0, offset as f64, size.0 as f64);
     }
     fn set_blend_color(&mut self, color: wgt::Color) {
         self.0
@@ -830,7 +832,9 @@ impl crate::Context for Context {
                         let mut mapped_buffer_binding =
                             web_sys::GpuBufferBinding::new(&buffer_slice.buffer.id.0);
                         mapped_buffer_binding.offset(buffer_slice.offset as f64);
-                        mapped_buffer_binding.size(buffer_slice.size_or_0() as f64);
+                        if buffer_slice.size != wgt::BufferSize::WHOLE {
+                            mapped_buffer_binding.size(buffer_slice.size.0 as f64);
+                        }
                         JsValue::from(mapped_buffer_binding.clone())
                     }
                     BindingResource::Sampler(ref sampler) => JsValue::from(sampler.id.0.clone()),
@@ -1046,8 +1050,7 @@ impl crate::Context for Context {
     fn buffer_map_read(
         &self,
         buffer: &Self::BufferId,
-        _start: wgt::BufferAddress,
-        _size: wgt::BufferAddress,
+        _range: Range<wgt::BufferAddress>,
     ) -> Self::MapReadFuture {
         MakeSendFuture(MapFuture {
             child: wasm_bindgen_futures::JsFuture::from(buffer.0.map_read_async()),
@@ -1059,8 +1062,7 @@ impl crate::Context for Context {
     fn buffer_map_write(
         &self,
         buffer: &Self::BufferId,
-        _start: wgt::BufferAddress,
-        _size: wgt::BufferAddress,
+        _range: Range<wgt::BufferAddress>,
     ) -> Self::MapWriteFuture {
         MakeSendFuture(MapFuture {
             child: wasm_bindgen_futures::JsFuture::from(buffer.0.map_write_async()),
@@ -1076,13 +1078,10 @@ impl crate::Context for Context {
     fn swap_chain_get_next_texture(
         &self,
         swap_chain: &Self::SwapChainId,
-    ) -> Result<(Self::TextureViewId, Self::SwapChainOutputDetail), crate::TimeOut> {
+    ) -> (Option<Self::TextureViewId>, SwapChainStatus, Self::SwapChainOutputDetail) {
         // TODO: Should we pass a descriptor here?
         // Or is the default view always correct?
-        Ok((
-            Sendable(swap_chain.0.get_current_texture().create_view()),
-            (),
-        ))
+        (Some(Sendable(swap_chain.0.get_current_texture().create_view())), SwapChainStatus::Good, ())
     }
 
     fn swap_chain_present(


### PR DESCRIPTION
Depends on https://github.com/gfx-rs/wgpu/pull/668.

This creates a new type `SwapChainResult` just for the method. 
It also alters the signature of `Context::swap_chain_get_next_texture` to return 
```rust
(Option<Self::TextureViewId>, wgt::SwapChainStatus, Self::SwapChainOutputDetail)
```
which is a little ugly but I couldn't think of anything better. 