### PR TITLE
Enable X11 in Vulkan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ smallvec = "1"
 raw-window-handle = "0.3"
 parking_lot = "0.10"
 
-//Note: we may consider switching this to "dev-dependencies" if users
-// want to opt into X11 explicitly.
+#Note: we may consider switching this to "dev-dependencies" if users
+# want to opt into X11 explicitly.
 [target.'cfg(all(unix, not(target_os = "ios"), not(target_os = "macos")))'.dependencies]
 gfx-backend-vulkan = { version = "0.5", features = ["x11"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,11 @@ smallvec = "1"
 raw-window-handle = "0.3"
 parking_lot = "0.10"
 
+//Note: we may consider switching this to "dev-dependencies" if users
+// want to opt into X11 explicitly.
+[target.'cfg(all(unix, not(target_os = "ios"), not(target_os = "macos")))'.dependencies]
+gfx-backend-vulkan = { version = "0.5", features = ["x11"] }
+
 [dev-dependencies]
 cgmath = "0.17"
 log = "0.4"


### PR DESCRIPTION
Closes #334 (as an alternative)
It was disabled by default by https://github.com/gfx-rs/wgpu/pull/678
This PR brings the old behavior back. We'll still need to consider it if makes sense to switch it to be optional.