### PR TITLE
Add Extension/Limit Interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,14 @@ vulkan = ["wgc/gfx-backend-vulkan"]
 package = "wgpu-core"
 version = "0.5"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "1a569ebe89deabca2d8299a664d5cad4b437d8d8"
+rev = "3a6cdeec945b6e2795c5ad544101b273c3887037"
 features = ["raw-window-handle"]
 
 [dependencies.wgt]
 package = "wgpu-types"
 version = "0.5"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "1a569ebe89deabca2d8299a664d5cad4b437d8d8"
+rev = "3a6cdeec945b6e2795c5ad544101b273c3887037"
 
 [dependencies]
 arrayvec = "0.5"

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -205,6 +205,7 @@ impl framework::Example for Example {
             lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             compare: wgpu::CompareFunction::Undefined,
+            anisotropy_clamp: 1,
         });
         let mx_total = Self::generate_matrix(sc_desc.width as f32 / sc_desc.height as f32);
         let mx_ref: &[f32; 16] = mx_total.as_ref();

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -157,6 +157,7 @@ impl Example {
             lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             compare: wgpu::CompareFunction::Undefined,
+            anisotropy_clamp: 1,
         });
 
         let views = (0..mip_count)
@@ -309,6 +310,7 @@ impl framework::Example for Example {
             lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             compare: wgpu::CompareFunction::Undefined,
+            anisotropy_clamp: 1,
         });
         let mx_total = Self::generate_matrix(sc_desc.width as f32 / sc_desc.height as f32);
         let mx_ref: &[f32; 16] = mx_total.as_ref();

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -351,6 +351,7 @@ impl framework::Example for Example {
             lod_min_clamp: -100.0,
             lod_max_clamp: 100.0,
             compare: wgpu::CompareFunction::LessEqual,
+            anisotropy_clamp: 1,
         });
 
         let shadow_texture = device.create_texture(&wgpu::TextureDescriptor {

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -130,6 +130,7 @@ impl framework::Example for Skybox {
             lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             compare: wgpu::CompareFunction::Undefined,
+            anisotropy_clamp: 1,
         });
 
         let paths: [&'static [u8]; 6] = [

--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -1,7 +1,7 @@
 use crate::{
     backend::native_gpu_future, BindGroupDescriptor, BindGroupLayoutDescriptor, BindingResource,
-    BindingType, BufferDescriptor, CommandEncoderDescriptor, ComputePipelineDescriptor,
-    PipelineLayoutDescriptor, RenderPipelineDescriptor, SamplerDescriptor, SwapChainStatus,
+    BindingType, BufferDescriptor, CommandEncoderDescriptor, ComputePipelineDescriptor, Extensions,
+    Limits, PipelineLayoutDescriptor, RenderPipelineDescriptor, SamplerDescriptor, SwapChainStatus,
     TextureDescriptor, TextureViewDescriptor, TextureViewDimension,
 };
 
@@ -249,6 +249,22 @@ impl crate::Context for Context {
     ) -> Self::RequestDeviceFuture {
         let device_id = gfx_select!(*adapter => self.adapter_request_device(*adapter, desc, trace_dir, PhantomData));
         ready(Ok((device_id, device_id)))
+    }
+
+    fn adapter_extensions(&self, adapter: &Self::AdapterId) -> Extensions {
+        gfx_select!(*adapter => self.adapter_extensions(*adapter))
+    }
+
+    fn adapter_limits(&self, adapter: &Self::AdapterId) -> Limits {
+        gfx_select!(*adapter => self.adapter_limits(*adapter))
+    }
+
+    fn device_extensions(&self, device: &Self::DeviceId) -> Extensions {
+        gfx_select!(*device => self.device_extensions(*device))
+    }
+
+    fn device_limits(&self, device: &Self::DeviceId) -> Limits {
+        gfx_select!(*device => self.device_limits(*device))
     }
 
     fn device_create_swap_chain(

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -720,6 +720,30 @@ impl crate::Context for Context {
         )
     }
 
+    fn adapter_extensions(&self, adapter: &Self::AdapterId) -> wgt::Extensions {
+        // TODO: web-sys has no way of getting extensions on adapters
+        wgt::Extensions {
+            anisotropic_filtering: false,
+        }
+    }
+
+    fn adapter_limits(&self, adapter: &Self::AdapterId) -> wgt::Limits {
+        // TODO: web-sys has no way of getting limits on adapters
+        wgt::Limits::default()
+    }
+
+    fn device_extensions(&self, device: &Self::DeviceId) -> wgt::Extensions {
+        // TODO: web-sys has no way of getting extensions on devices
+        wgt::Extensions {
+            anisotropic_filtering: false,
+        }
+    }
+
+    fn device_limits(&self, device: &Self::DeviceId) -> wgt::Limits {
+        // TODO: web-sys has a method for getting limits on devices, but it returns Object not GpuLimit
+        wgt::Limits::default()
+    }
+
     fn device_create_swap_chain(
         &self,
         device: &Self::DeviceId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,11 @@ trait Context: Sized {
         desc: &DeviceDescriptor,
         trace_dir: Option<&std::path::Path>,
     ) -> Self::RequestDeviceFuture;
+    fn adapter_extensions(&self, adapter: &Self::AdapterId) -> Extensions;
+    fn adapter_limits(&self, adapter: &Self::AdapterId) -> Limits;
 
+    fn device_extensions(&self, device: &Self::DeviceId) -> Extensions;
+    fn device_limits(&self, device: &Self::DeviceId) -> Limits;
     fn device_create_swap_chain(
         &self,
         device: &Self::DeviceId,
@@ -999,6 +1003,14 @@ impl Adapter {
         })
     }
 
+    pub fn extensions(&self) -> Extensions {
+        Context::adapter_extensions(&*self.context, &self.id)
+    }
+
+    pub fn limits(&self) -> Limits {
+        Context::adapter_limits(&*self.context, &self.id)
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     pub fn get_info(&self) -> AdapterInfo {
         //wgn::adapter_get_info(self.id)
@@ -1010,6 +1022,14 @@ impl Device {
     /// Check for resource cleanups and mapping callbacks.
     pub fn poll(&self, maintain: Maintain) {
         Context::device_poll(&*self.context, &self.id, maintain);
+    }
+
+    pub fn extensions(&self) -> Extensions {
+        Context::device_extensions(&*self.context, &self.id)
+    }
+
+    pub fn limits(&self) -> Limits {
+        Context::device_limits(&*self.context, &self.id)
     }
 
     /// Creates a shader module from SPIR-V source code.


### PR DESCRIPTION
Follow up to https://github.com/gfx-rs/wgpu/pull/690.

This forwards the extension/limit access interface into wgpu-rs.

It appears that the web-sys doesn't actually implement any of the methods we need, so I had them return the defaults. `Device::limits` exists, but it returns `Object` not `GpuLimits`, so doesn't appear usable.