### PR TITLE
Add Makefile for shader compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+# This Makefile generates SPIR-V shaders from GLSL shaders in the examples.
+
+shader_compiler = glslangValidator
+
+# All input shaders.
+glsls = $(wildcard examples/*/*.vert examples/*/*.frag examples/*/*.comp)
+
+# All SPIR-V targets.
+spirvs = $(addsuffix .spv,$(glsls))
+
+.PHONY: default
+default: $(spirvs)
+
+# Rule for making a SPIR-V target.
+$(spirvs): %.spv: %
+	$(shader_compiler) -V $< -o $@
+
+.PHONY: clean
+clean:
+	rm -f $(spirvs)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ Create an `index.html` file into `target/generated` directory and add the follow
 Now run a web server locally inside the `target/generated` directory to see the `hello-triangle` in the browser.
 e.g. `python -m http.server`
 
+### How to compile the shaders in the examples
+
+Currently, shaders in the examples are written in GLSL 4.50 and compiled to SPIR-V manually.
+In the future [WGSL](https://gpuweb.github.io/gpuweb/wgsl.html) will be the shader language for WebGPU, but support is not implemented yet.
+
+For now, the shaders can be compiled to SPIR-V by running `make`, which requires you to have `glslang`s `glslangValidator` binary.
+
 ## Friends
 
 Shout out to the following projects that work best with wgpu-rs:


### PR DESCRIPTION
I couldn't find clear instructions on how to compile the shaders in the examples, and had to do some digging. So I added instructions to the README to hopefully save other people's time.

Sidenote: When I compile the shaders as they are now (with my instructions), I end up with different `.spv` shaders with (seemingly) equivalent behaviour. I expect this is due to a different version/environment of `glslang` (see below) but it could be a mistake on my part.

```
> glslangValidator --version        
Glslang Version: 8.13.3743
ESSL Version: OpenGL ES GLSL 3.20 glslang Khronos. 13.3743
GLSL Version: 4.60 glslang Khronos. 13.3743
SPIR-V Version 0x00010500, Revision 3
GLSL.std.450 Version 100, Revision 1
Khronos Tool ID 8
SPIR-V Generator Version 8
GL_KHR_vulkan_glsl version 100
ARB_GL_gl_spirv version 100
```

Cheers!