### PR TITLE
Implement Extensions Interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,14 @@ vulkan = ["wgc/gfx-backend-vulkan"]
 package = "wgpu-core"
 version = "0.5"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "ac9587e9ced5b043abad68e260cb8c9e812cffb5"
+rev = "041db60f9080769b5edc40888cf9683ccb255399"
 features = ["raw-window-handle"]
 
 [dependencies.wgt]
 package = "wgpu-types"
 version = "0.5"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "ac9587e9ced5b043abad68e260cb8c9e812cffb5"
+rev = "041db60f9080769b5edc40888cf9683ccb255399"
 
 [dependencies]
 arrayvec = "0.5"

--- a/examples/capture/main.rs
+++ b/examples/capture/main.rs
@@ -1,10 +1,10 @@
+use std::env;
 /// This example shows how to capture an image by rendering it to a texture, copying the texture to
 /// a buffer, and retrieving it from the buffer. This could be used for "taking a screenshot," with
 /// the added benefit that this method doesn't require a window to be created.
 use std::fs::File;
-use std::mem::size_of;
-use std::env;
 use std::io::Write;
+use std::mem::size_of;
 
 async fn run() {
     let adapter = wgpu::Instance::new()
@@ -13,6 +13,7 @@ async fn run() {
                 power_preference: wgpu::PowerPreference::Default,
                 compatible_surface: None,
             },
+            wgpu::UnsafeExtensions::disallow(),
             wgpu::BackendBit::PRIMARY,
         )
         .await
@@ -132,7 +133,11 @@ async fn run() {
     if let Ok(()) = buffer_future.await {
         let padded_buffer = output_buffer.get_mapped_range(0, wgt::BufferSize::WHOLE);
 
-        let mut png_encoder = png::Encoder::new(File::create("red.png").unwrap(), width as u32, height as u32);
+        let mut png_encoder = png::Encoder::new(
+            File::create("red.png").unwrap(),
+            width as u32,
+            height as u32,
+        );
         png_encoder.set_depth(png::BitDepth::Eight);
         png_encoder.set_color(png::ColorType::RGBA);
         let mut png_writer = png_encoder

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -205,7 +205,7 @@ impl framework::Example for Example {
             lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             compare: None,
-            anisotropy_clamp: None,
+            ..Default::default()
         });
         let mx_total = Self::generate_matrix(sc_desc.width as f32 / sc_desc.height as f32);
         let mx_ref: &[f32; 16] = mx_total.as_ref();

--- a/examples/describe/main.rs
+++ b/examples/describe/main.rs
@@ -6,6 +6,7 @@ async fn run() {
                 power_preference: wgpu::PowerPreference::Default,
                 compatible_surface: None,
             },
+            unsafe { wgpu::UnsafeExtensions::allow() },
             wgpu::BackendBit::PRIMARY,
         )
         .await

--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -66,6 +66,7 @@ async fn run_async<E: Example>(event_loop: EventLoop<()>, window: Window) {
                 power_preference: wgpu::PowerPreference::Default,
                 compatible_surface: Some(&surface),
             },
+            wgpu::UnsafeExtensions::disallow(),
             wgpu::BackendBit::PRIMARY,
         )
         .await

--- a/examples/hello-compute/main.rs
+++ b/examples/hello-compute/main.rs
@@ -29,6 +29,7 @@ async fn execute_gpu(numbers: Vec<u32>) -> Vec<u32> {
                 power_preference: wgpu::PowerPreference::Default,
                 compatible_surface: None,
             },
+            wgpu::UnsafeExtensions::disallow(),
             wgpu::BackendBit::PRIMARY,
         )
         .await

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -14,6 +14,7 @@ async fn run(event_loop: EventLoop<()>, window: Window, swapchain_format: wgpu::
                 power_preference: wgpu::PowerPreference::Default,
                 compatible_surface: Some(&surface),
             },
+            wgpu::UnsafeExtensions::disallow(),
             wgpu::BackendBit::PRIMARY,
         )
         .await

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -157,7 +157,7 @@ impl Example {
             lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             compare: None,
-            anisotropy_clamp: None,
+            ..Default::default()
         });
 
         let views = (0..mip_count)
@@ -310,7 +310,7 @@ impl framework::Example for Example {
             lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             compare: None,
-            anisotropy_clamp: None,
+            ..Default::default()
         });
         let mx_total = Self::generate_matrix(sc_desc.width as f32 / sc_desc.height as f32);
         let mx_ref: &[f32; 16] = mx_total.as_ref();

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -353,7 +353,7 @@ impl framework::Example for Example {
             lod_min_clamp: -100.0,
             lod_max_clamp: 100.0,
             compare: Some(wgpu::CompareFunction::LessEqual),
-            anisotropy_clamp: None,
+            ..Default::default()
         });
 
         let shadow_texture = device.create_texture(&wgpu::TextureDescriptor {

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -130,7 +130,7 @@ impl framework::Example for Skybox {
             lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             compare: None,
-            anisotropy_clamp: None,
+            ..Default::default()
         });
 
         let paths: [&'static [u8]; 6] = [

--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -223,6 +223,7 @@ impl crate::Context for Context {
     fn instance_request_adapter(
         &self,
         options: &crate::RequestAdapterOptions<'_>,
+        unsafe_extensions: wgt::UnsafeExtensions,
         backends: wgt::BackendBit,
     ) -> Self::RequestAdapterFuture {
         let id = self.pick_adapter(
@@ -230,6 +231,7 @@ impl crate::Context for Context {
                 power_preference: options.power_preference,
                 compatible_surface: options.compatible_surface.map(|surface| surface.id),
             },
+            unsafe_extensions,
             wgc::instance::AdapterInputs::Mask(backends, |_| PhantomData),
         );
         ready(id)

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -660,6 +660,7 @@ impl crate::Context for Context {
     fn instance_request_adapter(
         &self,
         options: &crate::RequestAdapterOptions<'_>,
+        _unsafe_extensions: wgt::UnsafeExtensions,
         _backends: wgt::BackendBit,
     ) -> Self::RequestAdapterFuture {
         //TODO: support this check, return `None` if the flag is not set.
@@ -689,6 +690,11 @@ impl crate::Context for Context {
         if trace_dir.is_some() {
             //Error: Tracing isn't supported on the Web target
         }
+        assert!(
+            !desc.extensions.intersects(crate::Extensions::ALL_NATIVE),
+            "The web backend doesn't support any native extensions. Enabled native extensions: {:?}",
+            desc.extensions & crate::Extensions::ALL_NATIVE
+        );
         let mut mapped_desc = web_sys::GpuDeviceDescriptor::new();
         // TODO: label, extensions
         let mut mapped_limits = web_sys::GpuLimits::new();


### PR DESCRIPTION
This implements https://github.com/gfx-rs/wgpu/pull/703 in wgpu-rs. Notable changes include the removal of the anisotropic field from the examples, in favor of the now mandatory `..Default::default()` syntax.