### PR TITLE
Revert "API update for RODS2"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,20 +28,20 @@ vulkan = ["wgc/gfx-backend-vulkan"]
 package = "wgpu-core"
 version = "0.5"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "2dd3439475de6ea59488a91ea7d66096d3aecbbf"
+rev = "d1deae5747f5bd0a6503c1462555f201eaae02c9"
 features = ["raw-window-handle"]
 
 [dependencies.wgt]
 package = "wgpu-types"
 version = "0.5"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "2dd3439475de6ea59488a91ea7d66096d3aecbbf"
+rev = "d1deae5747f5bd0a6503c1462555f201eaae02c9"
 
 [dependencies]
 arrayvec = "0.5"
 futures = "0.3"
 smallvec = "1"
-typed-arena = "2"
+typed-arena = "2.0.1"
 raw-window-handle = "0.3"
 parking_lot = "0.10"
 

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -224,10 +224,7 @@ impl framework::Example for Example {
                 },
                 wgpu::Binding {
                     binding: 1,
-                    resource: wgpu::BindingResource::TextureView {
-                        view: &texture_view,
-                        read_only_depth_stencil: false,
-                    },
+                    resource: wgpu::BindingResource::TextureView(&texture_view),
                 },
                 wgpu::Binding {
                     binding: 2,

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -180,10 +180,7 @@ impl Example {
                 bindings: &[
                     wgpu::Binding {
                         binding: 0,
-                        resource: wgpu::BindingResource::TextureView {
-                            view: &views[target_mip - 1],
-                            read_only_depth_stencil: false,
-                        },
+                        resource: wgpu::BindingResource::TextureView(&views[target_mip - 1]),
                     },
                     wgpu::Binding {
                         binding: 1,
@@ -331,10 +328,7 @@ impl framework::Example for Example {
                 },
                 wgpu::Binding {
                     binding: 1,
-                    resource: wgpu::BindingResource::TextureView {
-                        view: &texture_view,
-                        read_only_depth_stencil: false,
-                    },
+                    resource: wgpu::BindingResource::TextureView(&texture_view),
                 },
                 wgpu::Binding {
                     binding: 2,

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -575,10 +575,7 @@ impl framework::Example for Example {
                     },
                     wgpu::Binding {
                         binding: 2,
-                        resource: wgpu::BindingResource::TextureView {
-                            view: &shadow_view,
-                            read_only_depth_stencil: false,
-                        },
+                        resource: wgpu::BindingResource::TextureView(&shadow_view),
                     },
                     wgpu::Binding {
                         binding: 3,

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -222,10 +222,7 @@ impl framework::Example for Skybox {
                 },
                 wgpu::Binding {
                     binding: 1,
-                    resource: wgpu::BindingResource::TextureView {
-                        view: &texture_view,
-                        read_only_depth_stencil: false,
-                    },
+                    resource: wgpu::BindingResource::TextureView(&texture_view),
                 },
                 wgpu::Binding {
                     binding: 2,

--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -413,7 +413,7 @@ impl crate::Context for Context {
     ) -> Self::BindGroupId {
         use wgc::binding_model as bm;
 
-        let texture_view_arena: Arena<bm::TextureBinding> = Arena::new();
+        let texture_view_arena: Arena<wgc::id::TextureViewId> = Arena::new();
         let bindings = desc
             .bindings
             .iter()
@@ -427,21 +427,17 @@ impl crate::Context for Context {
                             size: buffer_slice.size,
                         })
                     }
-                    BindingResource::Sampler(sampler) => bm::BindingResource::Sampler(sampler.id),
-                    BindingResource::TextureView {
-                        view,
-                        read_only_depth_stencil,
-                    } => bm::BindingResource::TextureView(bm::TextureBinding {
-                        view_id: view.id,
-                        read_only_depth_stencil,
-                    }),
+                    BindingResource::Sampler(ref sampler) => {
+                        bm::BindingResource::Sampler(sampler.id)
+                    }
+                    BindingResource::TextureView(ref texture_view) => {
+                        bm::BindingResource::TextureView(texture_view.id)
+                    }
                     BindingResource::TextureViewArray(texture_view_array) => {
-                        bm::BindingResource::TextureViewArray(texture_view_arena.alloc_extend(
-                            texture_view_array.iter().map(|view| bm::TextureBinding {
-                                view_id: view.id,
-                                read_only_depth_stencil: false, //TODO
-                            }),
-                        ))
+                        bm::BindingResource::TextureViewArray(
+                            texture_view_arena
+                                .alloc_extend(texture_view_array.iter().map(|view| view.id)),
+                        )
                     }
                 },
             })

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -869,13 +869,12 @@ impl crate::Context for Context {
                         JsValue::from(mapped_buffer_binding.clone())
                     }
                     BindingResource::Sampler(ref sampler) => JsValue::from(sampler.id.0.clone()),
-                    BindingResource::TextureView {
-                        view: ref texture_view,
-                        read_only_depth_stencil: _,
-                    } => JsValue::from(texture_view.id.0.clone()),
-                    BindingResource::TextureViewArray(..) => panic!(
-                        "Web backend does not support SAMPLED_TEXTURE_BINDING_ARRAY extension"
-                    ),
+                    BindingResource::TextureView(ref texture_view) => {
+                        JsValue::from(texture_view.id.0.clone())
+                    }
+                    BindingResource::TextureViewArray(..) => {
+                        panic!("Web backend does not support BINDING_INDEXING extension")
+                    }
                 };
 
                 web_sys::GpuBindGroupEntry::new(binding.binding, &mapped_resource)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -700,10 +700,7 @@ pub struct Queue {
 pub enum BindingResource<'a> {
     Buffer(BufferSlice<'a>),
     Sampler(&'a Sampler),
-    TextureView {
-        view: &'a TextureView,
-        read_only_depth_stencil: bool,
-    },
+    TextureView(&'a TextureView),
     TextureViewArray(&'a [TextureView]),
 }
 


### PR DESCRIPTION
This reverts commit edb36105306f166d41789c383df5ee66d74f1287.
It also update `wgpu` dependency to https://github.com/gfx-rs/wgpu/pull/723