### PR TITLE
Update with minBufferBindingSize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,14 @@ vulkan = ["wgc/gfx-backend-vulkan"]
 package = "wgpu-core"
 version = "0.5"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "d1deae5747f5bd0a6503c1462555f201eaae02c9"
+rev = "fc2dd481b2713cd0eda6ffa540faeaf7418fd051"
 features = ["raw-window-handle"]
 
 [dependencies.wgt]
 package = "wgpu-types"
 version = "0.5"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "d1deae5747f5bd0a6503c1462555f201eaae02c9"
+rev = "fc2dd481b2713cd0eda6ffa540faeaf7418fd051"
 
 [dependencies]
 arrayvec = "0.5"

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -135,28 +135,28 @@ impl framework::Example for Example {
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: None,
             bindings: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStage::VERTEX,
-                    ty: wgpu::BindingType::UniformBuffer { dynamic: false },
-                    ..Default::default()
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
-                    ty: wgpu::BindingType::SampledTexture {
+                wgpu::BindGroupLayoutEntry::new(
+                    0,
+                    wgpu::ShaderStage::VERTEX,
+                    wgpu::BindingType::UniformBuffer {
+                        dynamic: false,
+                        min_binding_size: wgpu::NonZeroBufferAddress::new(64),
+                    },
+                ),
+                wgpu::BindGroupLayoutEntry::new(
+                    1,
+                    wgpu::ShaderStage::FRAGMENT,
+                    wgpu::BindingType::SampledTexture {
                         multisampled: false,
                         component_type: wgpu::TextureComponentType::Float,
                         dimension: wgpu::TextureViewDimension::D2,
                     },
-                    ..Default::default()
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 2,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler { comparison: false },
-                    ..Default::default()
-                },
+                ),
+                wgpu::BindGroupLayoutEntry::new(
+                    2,
+                    wgpu::ShaderStage::FRAGMENT,
+                    wgpu::BindingType::Sampler { comparison: false },
+                ),
             ],
         });
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -198,7 +198,6 @@ impl framework::Example for Example {
 
         // Create other resources
         let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            label: None,
             address_mode_u: wgpu::AddressMode::ClampToEdge,
             address_mode_v: wgpu::AddressMode::ClampToEdge,
             address_mode_w: wgpu::AddressMode::ClampToEdge,

--- a/examples/hello-compute/main.rs
+++ b/examples/hello-compute/main.rs
@@ -65,15 +65,15 @@ async fn execute_gpu(numbers: Vec<u32>) -> Vec<u32> {
 
     let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
         label: None,
-        bindings: &[wgpu::BindGroupLayoutEntry {
-            binding: 0,
-            visibility: wgpu::ShaderStage::COMPUTE,
-            ty: wgpu::BindingType::StorageBuffer {
+        bindings: &[wgpu::BindGroupLayoutEntry::new(
+            0,
+            wgpu::ShaderStage::COMPUTE,
+            wgpu::BindingType::StorageBuffer {
                 dynamic: false,
                 readonly: false,
+                min_binding_size: wgpu::NonZeroBufferAddress::new(4),
             },
-            ..Default::default()
-        }],
+        )],
     });
 
     let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -153,12 +153,6 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_compute_0() {
-        let input = vec![];
-        futures::executor::block_on(assert_execute_gpu(input, vec![]));
-    }
 
     #[test]
     fn test_compute_1() {

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -84,22 +84,20 @@ impl Example {
     ) {
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             bindings: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
-                    ty: wgpu::BindingType::SampledTexture {
+                wgpu::BindGroupLayoutEntry::new(
+                    0,
+                    wgpu::ShaderStage::FRAGMENT,
+                    wgpu::BindingType::SampledTexture {
                         multisampled: false,
                         component_type: wgpu::TextureComponentType::Float,
                         dimension: wgpu::TextureViewDimension::D2,
                     },
-                    ..Default::default()
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler { comparison: false },
-                    ..Default::default()
-                },
+                ),
+                wgpu::BindGroupLayoutEntry::new(
+                    1,
+                    wgpu::ShaderStage::FRAGMENT,
+                    wgpu::BindingType::Sampler { comparison: false },
+                ),
             ],
             label: None,
         });
@@ -229,28 +227,28 @@ impl framework::Example for Example {
         // Create pipeline layout
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             bindings: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStage::VERTEX,
-                    ty: wgpu::BindingType::UniformBuffer { dynamic: false },
-                    ..Default::default()
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
-                    ty: wgpu::BindingType::SampledTexture {
+                wgpu::BindGroupLayoutEntry::new(
+                    0,
+                    wgpu::ShaderStage::VERTEX,
+                    wgpu::BindingType::UniformBuffer {
+                        dynamic: false,
+                        min_binding_size: wgpu::NonZeroBufferAddress::new(64),
+                    },
+                ),
+                wgpu::BindGroupLayoutEntry::new(
+                    1,
+                    wgpu::ShaderStage::FRAGMENT,
+                    wgpu::BindingType::SampledTexture {
                         component_type: wgpu::TextureComponentType::Float,
                         multisampled: false,
                         dimension: wgpu::TextureViewDimension::D2,
                     },
-                    ..Default::default()
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 2,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler { comparison: false },
-                    ..Default::default()
-                },
+                ),
+                wgpu::BindGroupLayoutEntry::new(
+                    2,
+                    wgpu::ShaderStage::FRAGMENT,
+                    wgpu::BindingType::Sampler { comparison: false },
+                ),
             ],
             label: None,
         });

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -244,12 +244,18 @@ impl framework::Example for Example {
 
         let local_bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                bindings: &[wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
-                    ty: wgpu::BindingType::UniformBuffer { dynamic: false },
-                    ..Default::default()
-                }],
+                bindings: &[wgpu::BindGroupLayoutEntry::new(
+                    0,
+                    wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
+                    wgpu::BindingType::UniformBuffer {
+                        dynamic: false,
+                        min_binding_size: wgpu::NonZeroBufferAddress::new(mem::size_of::<
+                            EntityUniforms,
+                        >(
+                        )
+                            as _),
+                    },
+                )],
                 label: None,
             });
 
@@ -424,22 +430,24 @@ impl framework::Example for Example {
         };
 
         let shadow_pass = {
+            let uniform_size = mem::size_of::<ShadowUniforms>() as wgpu::BufferAddress;
             // Create pipeline layout
             let bind_group_layout =
                 device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                    bindings: &[wgpu::BindGroupLayoutEntry {
-                        binding: 0, // global
-                        visibility: wgpu::ShaderStage::VERTEX,
-                        ty: wgpu::BindingType::UniformBuffer { dynamic: false },
-                        ..Default::default()
-                    }],
+                    bindings: &[wgpu::BindGroupLayoutEntry::new(
+                        0, // global
+                        wgpu::ShaderStage::VERTEX,
+                        wgpu::BindingType::UniformBuffer {
+                            dynamic: false,
+                            min_binding_size: wgpu::NonZeroBufferAddress::new(uniform_size),
+                        },
+                    )],
                     label: None,
                 });
             let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 bind_group_layouts: &[&bind_group_layout, &local_bind_group_layout],
             });
 
-            let uniform_size = mem::size_of::<ShadowUniforms>() as wgpu::BufferAddress;
             let uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
                 label: None,
                 size: uniform_size,
@@ -516,34 +524,42 @@ impl framework::Example for Example {
             let bind_group_layout =
                 device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                     bindings: &[
-                        wgpu::BindGroupLayoutEntry {
-                            binding: 0, // global
-                            visibility: wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
-                            ty: wgpu::BindingType::UniformBuffer { dynamic: false },
-                            ..Default::default()
-                        },
-                        wgpu::BindGroupLayoutEntry {
-                            binding: 1, // lights
-                            visibility: wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
-                            ty: wgpu::BindingType::UniformBuffer { dynamic: false },
-                            ..Default::default()
-                        },
-                        wgpu::BindGroupLayoutEntry {
-                            binding: 2,
-                            visibility: wgpu::ShaderStage::FRAGMENT,
-                            ty: wgpu::BindingType::SampledTexture {
+                        wgpu::BindGroupLayoutEntry::new(
+                            0, // global
+                            wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
+                            wgpu::BindingType::UniformBuffer {
+                                dynamic: false,
+                                min_binding_size: wgpu::NonZeroBufferAddress::new(mem::size_of::<
+                                    ForwardUniforms,
+                                >(
+                                )
+                                    as _),
+                            },
+                        ),
+                        wgpu::BindGroupLayoutEntry::new(
+                            1, // lights
+                            wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
+                            wgpu::BindingType::UniformBuffer {
+                                dynamic: false,
+                                min_binding_size: wgpu::NonZeroBufferAddress::new(
+                                    light_uniform_size,
+                                ),
+                            },
+                        ),
+                        wgpu::BindGroupLayoutEntry::new(
+                            2,
+                            wgpu::ShaderStage::FRAGMENT,
+                            wgpu::BindingType::SampledTexture {
                                 multisampled: false,
                                 component_type: wgpu::TextureComponentType::Float,
                                 dimension: wgpu::TextureViewDimension::D2Array,
                             },
-                            ..Default::default()
-                        },
-                        wgpu::BindGroupLayoutEntry {
-                            binding: 3,
-                            visibility: wgpu::ShaderStage::FRAGMENT,
-                            ty: wgpu::BindingType::Sampler { comparison: true },
-                            ..Default::default()
-                        },
+                        ),
+                        wgpu::BindGroupLayoutEntry::new(
+                            3,
+                            wgpu::ShaderStage::FRAGMENT,
+                            wgpu::BindingType::Sampler { comparison: true },
+                        ),
                     ],
                     label: None,
                 });

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -42,28 +42,28 @@ impl framework::Example for Skybox {
     ) -> (Self, Option<wgpu::CommandBuffer>) {
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             bindings: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
-                    ty: wgpu::BindingType::UniformBuffer { dynamic: false },
-                    ..Default::default()
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
-                    ty: wgpu::BindingType::SampledTexture {
+                wgpu::BindGroupLayoutEntry::new(
+                    0,
+                    wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
+                    wgpu::BindingType::UniformBuffer {
+                        dynamic: false,
+                        min_binding_size: None,
+                    },
+                ),
+                wgpu::BindGroupLayoutEntry::new(
+                    1,
+                    wgpu::ShaderStage::FRAGMENT,
+                    wgpu::BindingType::SampledTexture {
                         component_type: wgpu::TextureComponentType::Float,
                         multisampled: false,
                         dimension: wgpu::TextureViewDimension::Cube,
                     },
-                    ..Default::default()
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 2,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler { comparison: false },
-                    ..Default::default()
-                },
+                ),
+                wgpu::BindGroupLayoutEntry::new(
+                    2,
+                    wgpu::ShaderStage::FRAGMENT,
+                    wgpu::BindingType::Sampler { comparison: false },
+                ),
             ],
             label: None,
         });

--- a/examples/texture-arrays/main.rs
+++ b/examples/texture-arrays/main.rs
@@ -144,12 +144,14 @@ impl framework::Example for Example {
 
             let bind_group_layout =
                 device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                    bindings: &[wgpu::BindGroupLayoutEntry {
-                        binding: 0,
-                        visibility: wgpu::ShaderStage::FRAGMENT,
-                        ty: wgpu::BindingType::UniformBuffer { dynamic: false },
-                        ..wgpu::BindGroupLayoutEntry::default()
-                    }],
+                    bindings: &[wgpu::BindGroupLayoutEntry::new(
+                        0,
+                        wgpu::ShaderStage::FRAGMENT,
+                        wgpu::BindingType::UniformBuffer {
+                            dynamic: false,
+                            min_binding_size: None,
+                        },
+                    )],
                     label: Some("uniform workaround bind group layout"),
                 });
 
@@ -248,26 +250,26 @@ impl framework::Example for Example {
         let sampler = device.create_sampler(&wgpu::SamplerDescriptor::default());
 
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("bind group layout"),
             bindings: &[
                 wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
-                    ty: wgpu::BindingType::SampledTexture {
-                        component_type: wgpu::TextureComponentType::Float,
-                        dimension: wgpu::TextureViewDimension::D2,
-                        multisampled: false,
-                    },
                     count: Some(2),
-                    ..Default::default()
+                    ..wgpu::BindGroupLayoutEntry::new(
+                        0,
+                        wgpu::ShaderStage::FRAGMENT,
+                        wgpu::BindingType::SampledTexture {
+                            component_type: wgpu::TextureComponentType::Float,
+                            dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                    )
                 },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler { comparison: false },
-                    ..Default::default()
-                },
+                wgpu::BindGroupLayoutEntry::new(
+                    1,
+                    wgpu::ShaderStage::FRAGMENT,
+                    wgpu::BindingType::Sampler { comparison: false },
+                ),
             ],
-            label: Some("bind group layout"),
         });
 
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -806,14 +806,20 @@ impl crate::Context for Context {
                 );
 
                 match bind.ty {
-                    BindingType::UniformBuffer { dynamic }
+                    BindingType::UniformBuffer { dynamic, .. }
                     | BindingType::StorageBuffer { dynamic, .. } => {
                         mapped_entry.has_dynamic_offset(dynamic);
                     }
                     _ => {}
                 }
 
-                if let BindingType::SampledTexture { multisampled, .. } = bind.ty {
+                if let BindingType::SampledTexture {
+                    component_type,
+                    multisampled,
+                    ..
+                } = bind.ty
+                {
+                    mapped_entry.texture_component_type(map_texture_component_type(component_type));
                     mapped_entry.multisampled(multisampled);
                 }
 
@@ -827,15 +833,6 @@ impl crate::Context for Context {
 
                 if let BindingType::StorageTexture { format, .. } = bind.ty {
                     mapped_entry.storage_texture_format(map_texture_format(format));
-                }
-
-                match bind.ty {
-                    BindingType::SampledTexture { component_type, .. }
-                    | BindingType::StorageTexture { component_type, .. } => {
-                        mapped_entry
-                            .texture_component_type(map_texture_component_type(component_type));
-                    }
-                    _ => {}
                 }
 
                 mapped_entry

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! A cross-platform graphics and compute library based on WebGPU.
 
 mod backend;
-
+mod util;
 #[macro_use]
 mod macros;
 
@@ -19,20 +19,21 @@ use parking_lot::Mutex;
 #[cfg(not(target_arch = "wasm32"))]
 pub use wgc::instance::{AdapterInfo, DeviceType};
 pub use wgt::{
-    read_spirv, AddressMode, Backend, BackendBit, BindGroupLayoutDescriptor, BindGroupLayoutEntry,
-    BindingType, BlendDescriptor, BlendFactor, BlendOperation, BufferAddress, BufferSize,
-    BufferUsage, Capabilities, Color, ColorStateDescriptor, ColorWrite, CommandBufferDescriptor,
+    AddressMode, Backend, BackendBit, BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingType,
+    BlendDescriptor, BlendFactor, BlendOperation, BufferAddress, BufferSize, BufferUsage,
+    Capabilities, Color, ColorStateDescriptor, ColorWrite, CommandBufferDescriptor,
     CompareFunction, CullMode, DepthStencilStateDescriptor, DeviceDescriptor, DynamicOffset,
     Extensions, Extent3d, FilterMode, FrontFace, IndexFormat, InputStepMode, Limits, LoadOp,
-    Origin3d, PowerPreference, PresentMode, PrimitiveTopology, RasterizationStateDescriptor,
-    RenderBundleEncoderDescriptor, ShaderLocation, ShaderStage, StencilOperation,
-    StencilStateFaceDescriptor, StoreOp, SwapChainDescriptor, SwapChainStatus, TextureAspect,
-    TextureComponentType, TextureDataLayout, TextureDimension, TextureFormat, TextureUsage,
-    TextureViewDimension, UnsafeExtensions, VertexAttributeDescriptor, VertexFormat,
+    NonZeroBufferAddress, Origin3d, PowerPreference, PresentMode, PrimitiveTopology,
+    RasterizationStateDescriptor, RenderBundleEncoderDescriptor, ShaderLocation, ShaderStage,
+    StencilOperation, StencilStateFaceDescriptor, StoreOp, SwapChainDescriptor, SwapChainStatus,
+    TextureAspect, TextureComponentType, TextureDataLayout, TextureDimension, TextureFormat,
+    TextureUsage, TextureViewDimension, UnsafeExtensions, VertexAttributeDescriptor, VertexFormat,
     BIND_BUFFER_ALIGNMENT, COPY_BYTES_PER_ROW_ALIGNMENT,
 };
 
 use backend::Context as C;
+pub use util::read_spirv;
 
 trait ComputePassInner<Ctx: Context> {
     fn set_pipeline(&mut self, pipeline: &Ctx::ComputePipelineId);

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,41 @@
+use std::{io, slice};
+
+// TODO: This is copy/pasted from gfx-hal, so we need to find a new place to put
+// this function
+pub fn read_spirv<R: io::Read + io::Seek>(mut x: R) -> io::Result<Vec<u32>> {
+    let size = x.seek(io::SeekFrom::End(0))?;
+    if size % 4 != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "input length not divisible by 4",
+        ));
+    }
+    if size > usize::max_value() as u64 {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "input too long"));
+    }
+    let words = (size / 4) as usize;
+    let mut result = Vec::<u32>::with_capacity(words);
+    x.seek(io::SeekFrom::Start(0))?;
+    unsafe {
+        // Writing all bytes through a pointer with less strict alignment when our type has no
+        // invalid bitpatterns is safe.
+        x.read_exact(slice::from_raw_parts_mut(
+            result.as_mut_ptr() as *mut u8,
+            words * 4,
+        ))?;
+        result.set_len(words);
+    }
+    const MAGIC_NUMBER: u32 = 0x0723_0203;
+    if !result.is_empty() && result[0] == MAGIC_NUMBER.swap_bytes() {
+        for word in &mut result {
+            *word = word.swap_bytes();
+        }
+    }
+    if result.is_empty() || result[0] != MAGIC_NUMBER {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "input missing SPIR-V magic number",
+        ));
+    }
+    Ok(result)
+}


### PR DESCRIPTION
Depends on https://github.com/gfx-rs/wgpu/pull/726
Also reverts #373 : buffer bindings now have to include at least one element of an unsized struct portion, so they can't be zero-sized.