### PR TITLE
Documentation Pass

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,6 @@
 //! Convenience macros
 
-/// Macro to produce an array of [`VertexAttributeDescriptor`]
+/// Macro to produce an array of [`VertexAttributeDescriptor`].
 ///
 /// Output has type: `[VertexAttributeDescriptor; _]`. Usage is as follows:
 /// ```
@@ -30,7 +30,9 @@ macro_rules! vertex_attr_array {
     };
 }
 
-// For internal usage
+/// Helper macro which turns a vertex attribute type into a size.
+///
+/// Mainly used as a helper for [`vertex_attr_array`] but might be externally useful.
 #[macro_export]
 macro_rules! vertex_format_size {
     (Uchar2) => {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,8 +1,16 @@
+/// Wrapper aligning contents to at least 4.
 #[repr(align(4))]
 pub struct WordAligned<Bytes: ?Sized>(pub Bytes);
 
 /// Treat the given by slice as a SPIR-V module.
-/// The pointer has to be aligned to 32-bit boundary and be a valid SPIR-V binary.
+///
+/// # Errors
+///
+/// Returns errors when:
+///
+/// - Input length is not divisible by 4
+/// - Input is longer than usize::max_value()
+/// - SPIR-V magic number is missing from beginning of stream
 pub fn make_spirv<'a>(data: &'a [u8]) -> super::ShaderModuleSource<'a> {
     const MAGIC_NUMBER: u32 = 0x0723_0203;
 


### PR DESCRIPTION
The wgpu-rs component of https://github.com/gfx-rs/wgpu/pull/728.

Closes #378.

Notable changes not mentioned in wgpu PR:
- Reexported the wgt-local types whenever we have a type definition. These are reexported as `ThingBase`. This is unfortunately the only way to actually get their documentation to show up, aliases have no way of "inheriting" the documentation.
- Added wgpu logo to docs!
- Hid vertex_format_size macro.