### PR TITLE
build master docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,23 @@
+name: Documentation
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v1
+
+      - name: build documentation
+        run: cargo doc --lib --all-features
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: target/doc
+          TARGET_FOLDER: doc 


### PR DESCRIPTION
builds docs and deploys to `doc/` folder on gh_pages branch

doesn't interfere with other gh_pages contents.

assumes `ACCESS_TOKEN` is set as a github secret (if it isn't, please see https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line)

see live example on my fork: https://dakom.github.io/wgpu-rs/doc/wgpu/index.html

* closes #379

