### PR TITLE
Change `include_spirv` macro to accept tokens

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -143,7 +143,7 @@ fn test_vertex_attr_array() {
 /// It ensure the word alignment as well as the magic number.
 #[macro_export]
 macro_rules! include_spirv {
-    ($path:expr) => {
-        $crate::util::make_spirv(&$crate::util::WordAligned(*include_bytes!($path)).0)
+    ($($token:tt)*) => {
+        $crate::util::make_spirv(&$crate::util::WordAligned(*include_bytes!($($token)*)).0)
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -143,7 +143,7 @@ fn test_vertex_attr_array() {
 /// It ensure the word alignment as well as the magic number.
 #[macro_export]
 macro_rules! include_spirv {
-    ($path:literal) => {
+    ($path:expr) => {
         $crate::util::make_spirv(&$crate::util::WordAligned(*include_bytes!($path)).0)
     };
 }


### PR DESCRIPTION
The `include_spirv` macros was set to accept literals only. Unfortunately, this means that other macros, such as `concat` and `env` aren't accepted, making it unusable with build script-compiled shaders. This change allows those macros to be used to load the SpirV at the expense of a potentially less helpful error message as the `literal` requirement is differed to the `include_bytes` invocation.