### PR TITLE
First Phase of Tracing Transition 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,15 @@ keywords = ["graphics"]
 license = "MPL-2.0"
 exclude = ["etc/**/*", "examples/**/*", "tests/**/*", "Cargo.lock", "target/**/*"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [lib]
 
 [features]
 default = []
 trace = ["wgc/trace"]
+subscriber = ["wgc/subscriber"]
 # Make Vulkan backend available on platforms where it is by default not, e.g. macOS
 vulkan = ["wgc/gfx-backend-vulkan"]
 
@@ -22,22 +26,23 @@ vulkan = ["wgc/gfx-backend-vulkan"]
 package = "wgpu-core"
 version = "0.5"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "6b3863af624741491f197ce504cc58586fe077b5"
+rev = "285b31a6a1d041cd8983f951817390a85191ac6d"
 features = ["raw-window-handle"]
 
 [dependencies.wgt]
 package = "wgpu-types"
 version = "0.5"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "6b3863af624741491f197ce504cc58586fe077b5"
+rev = "285b31a6a1d041cd8983f951817390a85191ac6d"
 
 [dependencies]
 arrayvec = "0.5"
 futures = "0.3"
-smallvec = "1"
-typed-arena = "2.0.1"
-raw-window-handle = "0.3"
 parking_lot = "0.10"
+raw-window-handle = "0.3"
+smallvec = "1"
+tracing = { version = "0.1", default-features = false, features = ["std"] }
+typed-arena = "2.0.1"
 
 #Note: we may consider switching this to "dev-dependencies" if users
 # want to opt into X11 explicitly.

--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -16,8 +16,7 @@ pub const OPENGL_TO_WGPU_MATRIX: cgmath::Matrix4<f32> = cgmath::Matrix4::new(
 
 #[allow(dead_code)]
 pub fn cast_slice<T>(data: &[T]) -> &[u8] {
-    use std::mem::size_of;
-    use std::slice::from_raw_parts;
+    use std::{mem::size_of, slice::from_raw_parts};
 
     unsafe { from_raw_parts(data.as_ptr() as *const u8, data.len() * size_of::<T>()) }
 }
@@ -191,7 +190,7 @@ pub fn run<E: Example>(title: &str) {
     let event_loop = EventLoop::new();
     let mut builder = winit::window::WindowBuilder::new();
     builder = builder.with_title(title);
-    #[cfg(windows_OFF)] //TODO
+    #[cfg(windows_OFF)] // TODO
     {
         use winit::platform::windows::WindowBuilderExtWindows;
         builder = builder.with_no_redirection_bitmap(true);
@@ -201,6 +200,13 @@ pub fn run<E: Example>(title: &str) {
     #[cfg(not(target_arch = "wasm32"))]
     {
         env_logger::init();
+
+        #[cfg(feature = "subscriber")]
+        {
+            let chrome_tracing_dir = std::env::var("WGPU_CHROME_TRACING");
+            wgpu::util::initialize_default_subscriber(chrome_tracing_dir.ok());
+        };
+
         futures::executor::block_on(run_async::<E>(event_loop, window));
     }
     #[cfg(target_arch = "wasm32")]

--- a/examples/hello-compute/main.rs
+++ b/examples/hello-compute/main.rs
@@ -137,6 +137,13 @@ fn main() {
     #[cfg(not(target_arch = "wasm32"))]
     {
         env_logger::init();
+
+        #[cfg(feature = "subscriber")]
+        {
+            let chrome_tracing_dir = std::env::var("WGPU_CHROME_TRACING");
+            wgpu::util::initialize_default_subscriber(chrome_tracing_dir.ok());
+        };
+
         futures::executor::block_on(run());
     }
     #[cfg(target_arch = "wasm32")]
@@ -165,9 +172,7 @@ mod tests {
 
     #[test]
     fn test_multithreaded_compute() {
-        use std::sync::mpsc;
-        use std::thread;
-        use std::time::Duration;
+        use std::{sync::mpsc, thread, time::Duration};
 
         let thread_count = 8;
 

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -142,6 +142,7 @@ fn main() {
     #[cfg(not(target_arch = "wasm32"))]
     {
         env_logger::init();
+
         // Temporarily avoid srgb formats for the swapchain on the web
         futures::executor::block_on(run(event_loop, window, wgpu::TextureFormat::Bgra8UnormSrgb));
     }

--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -184,6 +184,7 @@ mod pass_impl {
             &mut self,
             render_bundles: I,
         ) {
+            wgc::span!(_guard, TRACE, "RenderPass::execute_bundles wrapper");
             let temp_render_bundles = render_bundles.cloned().collect::<SmallVec<[_; 4]>>();
             unsafe {
                 wgpu_render_pass_execute_bundles(
@@ -450,6 +451,7 @@ impl crate::Context for Context {
         device: &Self::DeviceId,
         desc: &BindGroupDescriptor,
     ) -> Self::BindGroupId {
+        wgc::span!(_guard, TRACE, "Device::create_bind_group wrapper");
         use wgc::binding_model as bm;
 
         let texture_view_arena: Arena<wgc::id::TextureViewId> = Arena::new();
@@ -499,6 +501,7 @@ impl crate::Context for Context {
         device: &Self::DeviceId,
         desc: &PipelineLayoutDescriptor,
     ) -> Self::PipelineLayoutId {
+        wgc::span!(_guard, TRACE, "Device::create_pipeline_layout wrapper");
         //TODO: avoid allocation here
         let temp_layouts = desc
             .bind_group_layouts
@@ -522,6 +525,7 @@ impl crate::Context for Context {
         device: &Self::DeviceId,
         desc: &RenderPipelineDescriptor,
     ) -> Self::RenderPipelineId {
+        wgc::span!(_guard, TRACE, "Device::create_render_pipeline wrapper");
         use wgc::pipeline as pipe;
 
         let vertex_entry_point = CString::new(desc.vertex_stage.entry_point).unwrap();
@@ -697,6 +701,8 @@ impl crate::Context for Context {
         mode: MapMode,
         range: Range<wgt::BufferAddress>,
     ) -> Self::MapAsyncFuture {
+        wgc::span!(_guard, TRACE, "Buffer::buffer_map_async wrapper");
+
         let (future, completion) = native_gpu_future::new_gpu_future();
 
         extern "C" fn buffer_map_future_wrapper(
@@ -911,6 +917,7 @@ impl crate::Context for Context {
         encoder: &Self::CommandEncoderId,
         desc: &crate::RenderPassDescriptor<'a, '_>,
     ) -> Self::RenderPassId {
+        wgc::span!(_guard, TRACE, "CommandEncoder::begin_render_pass wrapper");
         let colors = desc
             .color_attachments
             .iter()

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(all(not(target_arch = "wasm32"), feature = "subscriber"))]
+pub use wgc::logging::subscriber::{initialize_default_subscriber, ChromeTracingLayer};
+
 /// Wrapper aligning contents to at least 4.
 #[repr(align(4))]
 pub struct WordAligned<Bytes: ?Sized>(pub Bytes);


### PR DESCRIPTION
## Connections

This is the wgpu-rs component of https://github.com/gfx-rs/wgpu/pull/740.

## Notable Changes
- Added annotations for non-trivial wrapper functions
- Enabled building all features on docs.rs
- Took a dep on tracing.
- Fixes an assert that randomly stopped compiling.
- Added env variable WGPU_CHROME_TRACING which will be a path to the output chrome trace, if the feature is enabled.
- Added feature which corresponds directly to wgc feature.