### PR TITLE
Update wgpu without peek-poke

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,14 @@ vulkan = ["wgc/gfx-backend-vulkan"]
 package = "wgpu-core"
 version = "0.5"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "a02a56684114da702a64e30af49d0167e273402b"
+rev = "c7be94047d156a3bde88d03cd5c229bedb6efe62"
 features = ["raw-window-handle"]
 
 [dependencies.wgt]
 package = "wgpu-types"
 version = "0.5"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "a02a56684114da702a64e30af49d0167e273402b"
+rev = "c7be94047d156a3bde88d03cd5c229bedb6efe62"
 
 [dependencies]
 arrayvec = "0.5"
@@ -67,6 +67,9 @@ test = true
 [patch."https://github.com/gfx-rs/wgpu"]
 #wgpu-types = { version = "0.5.0", path = "../wgpu/wgpu-types" }
 #wgpu-core = { version = "0.5.0", path = "../wgpu/wgpu-core" }
+
+[patch."https://github.com/gfx-rs/naga"]
+#naga = { path = "../naga" }
 
 [patch.crates-io]
 #gfx-hal = { version = "0.5.0", path = "../gfx/src/hal" }

--- a/examples/boids/main.rs
+++ b/examples/boids/main.rs
@@ -263,11 +263,9 @@ impl framework::Example for Example {
             color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                 attachment: &frame.view,
                 resolve_target: None,
-                channel: wgpu::PassChannel {
-                    load_op: wgpu::LoadOp::Clear,
-                    store_op: wgpu::StoreOp::Store,
-                    clear_value: wgpu::Color::BLACK,
-                    read_only: false,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                    store: true,
                 },
             }],
             depth_stencil_attachment: None,

--- a/examples/boids/main.rs
+++ b/examples/boids/main.rs
@@ -65,9 +65,7 @@ impl framework::Example for Example {
                         wgpu::ShaderStage::COMPUTE,
                         wgpu::BindingType::UniformBuffer {
                             dynamic: false,
-                            min_binding_size: wgpu::NonZeroBufferAddress::new(
-                                sim_param_data.len() as _
-                            ),
+                            min_binding_size: wgpu::BufferSize::new(sim_param_data.len() as _),
                         },
                     ),
                     wgpu::BindGroupLayoutEntry::new(
@@ -75,9 +73,7 @@ impl framework::Example for Example {
                         wgpu::ShaderStage::COMPUTE,
                         wgpu::BindingType::StorageBuffer {
                             dynamic: false,
-                            min_binding_size: wgpu::NonZeroBufferAddress::new(
-                                (NUM_PARTICLES * 16) as _,
-                            ),
+                            min_binding_size: wgpu::BufferSize::new((NUM_PARTICLES * 16) as _),
                             readonly: false,
                         },
                     ),
@@ -86,9 +82,7 @@ impl framework::Example for Example {
                         wgpu::ShaderStage::COMPUTE,
                         wgpu::BindingType::StorageBuffer {
                             dynamic: false,
-                            min_binding_size: wgpu::NonZeroBufferAddress::new(
-                                (NUM_PARTICLES * 16) as _,
-                            ),
+                            min_binding_size: wgpu::BufferSize::new((NUM_PARTICLES * 16) as _),
                             readonly: false,
                         },
                     ),
@@ -269,9 +263,12 @@ impl framework::Example for Example {
             color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                 attachment: &frame.view,
                 resolve_target: None,
-                load_op: wgpu::LoadOp::Clear,
-                store_op: wgpu::StoreOp::Store,
-                clear_color: wgpu::Color::BLACK,
+                channel: wgpu::PassChannel {
+                    load_op: wgpu::LoadOp::Clear,
+                    store_op: wgpu::StoreOp::Store,
+                    clear_value: wgpu::Color::BLACK,
+                    read_only: false,
+                },
             }],
             depth_stencil_attachment: None,
         };

--- a/examples/capture/main.rs
+++ b/examples/capture/main.rs
@@ -86,9 +86,12 @@ async fn run() {
             color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                 attachment: &texture.create_default_view(),
                 resolve_target: None,
-                load_op: wgpu::LoadOp::Clear,
-                store_op: wgpu::StoreOp::Store,
-                clear_color: wgpu::Color::RED,
+                channel: wgpu::PassChannel {
+                    load_op: wgpu::LoadOp::Clear,
+                    store_op: wgpu::StoreOp::Store,
+                    clear_value: wgpu::Color::RED,
+                    read_only: false,
+                },
             }],
             depth_stencil_attachment: None,
         });

--- a/examples/capture/main.rs
+++ b/examples/capture/main.rs
@@ -86,11 +86,9 @@ async fn run() {
             color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                 attachment: &texture.create_default_view(),
                 resolve_target: None,
-                channel: wgpu::PassChannel {
-                    load_op: wgpu::LoadOp::Clear,
-                    store_op: wgpu::StoreOp::Store,
-                    clear_value: wgpu::Color::RED,
-                    read_only: false,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::RED),
+                    store: true,
                 },
             }],
             depth_stencil_attachment: None,

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -326,16 +326,14 @@ impl framework::Example for Example {
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,
-                    channel: wgpu::PassChannel {
-                        load_op: wgpu::LoadOp::Clear,
-                        store_op: wgpu::StoreOp::Store,
-                        clear_value: wgpu::Color {
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color {
                             r: 0.1,
                             g: 0.2,
                             b: 0.3,
                             a: 1.0,
-                        },
-                        read_only: false,
+                        }),
+                        store: true,
                     },
                 }],
                 depth_stencil_attachment: None,

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -140,7 +140,7 @@ impl framework::Example for Example {
                     wgpu::ShaderStage::VERTEX,
                     wgpu::BindingType::UniformBuffer {
                         dynamic: false,
-                        min_binding_size: wgpu::NonZeroBufferAddress::new(64),
+                        min_binding_size: wgpu::BufferSize::new(64),
                     },
                 ),
                 wgpu::BindGroupLayoutEntry::new(
@@ -326,13 +326,16 @@ impl framework::Example for Example {
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,
-                    load_op: wgpu::LoadOp::Clear,
-                    store_op: wgpu::StoreOp::Store,
-                    clear_color: wgpu::Color {
-                        r: 0.1,
-                        g: 0.2,
-                        b: 0.3,
-                        a: 1.0,
+                    channel: wgpu::PassChannel {
+                        load_op: wgpu::LoadOp::Clear,
+                        store_op: wgpu::StoreOp::Store,
+                        clear_value: wgpu::Color {
+                            r: 0.1,
+                            g: 0.2,
+                            b: 0.3,
+                            a: 1.0,
+                        },
+                        read_only: false,
                     },
                 }],
                 depth_stencil_attachment: None,

--- a/examples/hello-compute/main.rs
+++ b/examples/hello-compute/main.rs
@@ -68,7 +68,7 @@ async fn execute_gpu(numbers: Vec<u32>) -> Vec<u32> {
             wgpu::BindingType::StorageBuffer {
                 dynamic: false,
                 readonly: false,
-                min_binding_size: wgpu::NonZeroBufferAddress::new(4),
+                min_binding_size: wgpu::BufferSize::new(4),
             },
         )],
     });

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -114,11 +114,9 @@ async fn run(event_loop: EventLoop<()>, window: Window, swapchain_format: wgpu::
                         color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                             attachment: &frame.view,
                             resolve_target: None,
-                            channel: wgpu::PassChannel {
-                                load_op: wgpu::LoadOp::Clear,
-                                store_op: wgpu::StoreOp::Store,
-                                clear_value: wgpu::Color::GREEN,
-                                read_only: false,
+                            ops: wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
+                                store: true,
                             },
                         }],
                         depth_stencil_attachment: None,

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -114,9 +114,12 @@ async fn run(event_loop: EventLoop<()>, window: Window, swapchain_format: wgpu::
                         color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                             attachment: &frame.view,
                             resolve_target: None,
-                            load_op: wgpu::LoadOp::Clear,
-                            store_op: wgpu::StoreOp::Store,
-                            clear_color: wgpu::Color::GREEN,
+                            channel: wgpu::PassChannel {
+                                load_op: wgpu::LoadOp::Clear,
+                                store_op: wgpu::StoreOp::Store,
+                                clear_value: wgpu::Color::GREEN,
+                                read_only: false,
+                            },
                         }],
                         depth_stencil_attachment: None,
                     });

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -186,11 +186,9 @@ impl Example {
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &views[target_mip],
                     resolve_target: None,
-                    channel: wgpu::PassChannel {
-                        load_op: wgpu::LoadOp::Clear,
-                        store_op: wgpu::StoreOp::Store,
-                        clear_value: wgpu::Color::WHITE,
-                        read_only: false,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::WHITE),
+                        store: true,
                     },
                 }],
                 depth_stencil_attachment: None,
@@ -411,20 +409,19 @@ impl framework::Example for Example {
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
         {
+            let clear_color = wgpu::Color {
+                r: 0.1,
+                g: 0.2,
+                b: 0.3,
+                a: 1.0,
+            };
             let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,
-                    channel: wgpu::PassChannel {
-                        load_op: wgpu::LoadOp::Clear,
-                        store_op: wgpu::StoreOp::Store,
-                        clear_value: wgpu::Color {
-                            r: 0.1,
-                            g: 0.2,
-                            b: 0.3,
-                            a: 1.0,
-                        },
-                        read_only: false,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(clear_color),
+                        store: true,
                     },
                 }],
                 depth_stencil_attachment: None,

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -186,9 +186,12 @@ impl Example {
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &views[target_mip],
                     resolve_target: None,
-                    load_op: wgpu::LoadOp::Clear,
-                    store_op: wgpu::StoreOp::Store,
-                    clear_color: wgpu::Color::WHITE,
+                    channel: wgpu::PassChannel {
+                        load_op: wgpu::LoadOp::Clear,
+                        store_op: wgpu::StoreOp::Store,
+                        clear_value: wgpu::Color::WHITE,
+                        read_only: false,
+                    },
                 }],
                 depth_stencil_attachment: None,
             });
@@ -226,7 +229,7 @@ impl framework::Example for Example {
                     wgpu::ShaderStage::VERTEX,
                     wgpu::BindingType::UniformBuffer {
                         dynamic: false,
-                        min_binding_size: wgpu::NonZeroBufferAddress::new(64),
+                        min_binding_size: wgpu::BufferSize::new(64),
                     },
                 ),
                 wgpu::BindGroupLayoutEntry::new(
@@ -412,13 +415,16 @@ impl framework::Example for Example {
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,
-                    load_op: wgpu::LoadOp::Clear,
-                    store_op: wgpu::StoreOp::Store,
-                    clear_color: wgpu::Color {
-                        r: 0.1,
-                        g: 0.2,
-                        b: 0.3,
-                        a: 1.0,
+                    channel: wgpu::PassChannel {
+                        load_op: wgpu::LoadOp::Clear,
+                        store_op: wgpu::StoreOp::Store,
+                        clear_value: wgpu::Color {
+                            r: 0.1,
+                            g: 0.2,
+                            b: 0.3,
+                            a: 1.0,
+                        },
+                        read_only: false,
                     },
                 }],
                 depth_stencil_attachment: None,

--- a/examples/msaa-line/main.rs
+++ b/examples/msaa-line/main.rs
@@ -255,23 +255,21 @@ impl framework::Example for Example {
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
         {
-            let channel = wgpu::PassChannel {
-                load_op: wgpu::LoadOp::Clear,
-                store_op: wgpu::StoreOp::Store,
-                clear_value: wgpu::Color::BLACK,
-                read_only: false,
+            let ops = wgpu::Operations {
+                load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                store: true,
             };
             let rpass_color_attachment = if self.sample_count == 1 {
                 wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,
-                    channel,
+                    ops,
                 }
             } else {
                 wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &self.multisampled_framebuffer,
                     resolve_target: Some(&frame.view),
-                    channel,
+                    ops,
                 }
             };
 

--- a/examples/msaa-line/main.rs
+++ b/examples/msaa-line/main.rs
@@ -255,21 +255,23 @@ impl framework::Example for Example {
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
         {
+            let channel = wgpu::PassChannel {
+                load_op: wgpu::LoadOp::Clear,
+                store_op: wgpu::StoreOp::Store,
+                clear_value: wgpu::Color::BLACK,
+                read_only: false,
+            };
             let rpass_color_attachment = if self.sample_count == 1 {
                 wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,
-                    load_op: wgpu::LoadOp::Clear,
-                    store_op: wgpu::StoreOp::Store,
-                    clear_color: wgpu::Color::BLACK,
+                    channel,
                 }
             } else {
                 wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &self.multisampled_framebuffer,
                     resolve_target: Some(&frame.view),
-                    load_op: wgpu::LoadOp::Clear,
-                    store_op: wgpu::StoreOp::Store,
-                    clear_color: wgpu::Color::BLACK,
+                    channel,
                 }
             };
 

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -247,11 +247,9 @@ impl framework::Example for Example {
                     wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
                     wgpu::BindingType::UniformBuffer {
                         dynamic: false,
-                        min_binding_size: wgpu::NonZeroBufferAddress::new(mem::size_of::<
-                            EntityUniforms,
-                        >(
-                        )
-                            as _),
+                        min_binding_size: wgpu::BufferSize::new(
+                            mem::size_of::<EntityUniforms>() as _
+                        ),
                     },
                 )],
                 label: None,
@@ -437,7 +435,7 @@ impl framework::Example for Example {
                         wgpu::ShaderStage::VERTEX,
                         wgpu::BindingType::UniformBuffer {
                             dynamic: false,
-                            min_binding_size: wgpu::NonZeroBufferAddress::new(uniform_size),
+                            min_binding_size: wgpu::BufferSize::new(uniform_size),
                         },
                     )],
                     label: None,
@@ -521,7 +519,7 @@ impl framework::Example for Example {
                             wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
                             wgpu::BindingType::UniformBuffer {
                                 dynamic: false,
-                                min_binding_size: wgpu::NonZeroBufferAddress::new(mem::size_of::<
+                                min_binding_size: wgpu::BufferSize::new(mem::size_of::<
                                     ForwardUniforms,
                                 >(
                                 )
@@ -533,9 +531,7 @@ impl framework::Example for Example {
                             wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
                             wgpu::BindingType::UniformBuffer {
                                 dynamic: false,
-                                min_binding_size: wgpu::NonZeroBufferAddress::new(
-                                    light_uniform_size,
-                                ),
+                                min_binding_size: wgpu::BufferSize::new(light_uniform_size),
                             },
                         ),
                         wgpu::BindGroupLayoutEntry::new(
@@ -760,14 +756,18 @@ impl framework::Example for Example {
                 color_attachments: &[],
                 depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachmentDescriptor {
                     attachment: &light.target_view,
-                    depth_load_op: wgpu::LoadOp::Clear,
-                    depth_store_op: wgpu::StoreOp::Store,
-                    depth_read_only: false,
-                    stencil_load_op: wgpu::LoadOp::Clear,
-                    stencil_store_op: wgpu::StoreOp::Store,
-                    clear_depth: 1.0,
-                    clear_stencil: 0,
-                    stencil_read_only: false,
+                    depth: wgpu::PassChannel {
+                        load_op: wgpu::LoadOp::Clear,
+                        store_op: wgpu::StoreOp::Store,
+                        clear_value: 1.0,
+                        read_only: false,
+                    },
+                    stencil: wgpu::PassChannel {
+                        load_op: wgpu::LoadOp::Clear,
+                        store_op: wgpu::StoreOp::Store,
+                        clear_value: 0,
+                        read_only: false,
+                    },
                 }),
             });
             pass.set_pipeline(&self.shadow_pass.pipeline);
@@ -787,25 +787,32 @@ impl framework::Example for Example {
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,
-                    load_op: wgpu::LoadOp::Clear,
-                    store_op: wgpu::StoreOp::Store,
-                    clear_color: wgpu::Color {
-                        r: 0.1,
-                        g: 0.2,
-                        b: 0.3,
-                        a: 1.0,
+                    channel: wgpu::PassChannel {
+                        load_op: wgpu::LoadOp::Clear,
+                        store_op: wgpu::StoreOp::Store,
+                        clear_value: wgpu::Color {
+                            r: 0.1,
+                            g: 0.2,
+                            b: 0.3,
+                            a: 1.0,
+                        },
+                        read_only: false,
                     },
                 }],
                 depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachmentDescriptor {
                     attachment: &self.forward_depth,
-                    depth_load_op: wgpu::LoadOp::Clear,
-                    depth_store_op: wgpu::StoreOp::Store,
-                    depth_read_only: false,
-                    stencil_load_op: wgpu::LoadOp::Clear,
-                    stencil_store_op: wgpu::StoreOp::Store,
-                    clear_depth: 1.0,
-                    clear_stencil: 0,
-                    stencil_read_only: false,
+                    depth: wgpu::PassChannel {
+                        load_op: wgpu::LoadOp::Clear,
+                        store_op: wgpu::StoreOp::Clear,
+                        clear_value: 1.0,
+                        read_only: false,
+                    },
+                    stencil: wgpu::PassChannel {
+                        load_op: wgpu::LoadOp::Clear,
+                        store_op: wgpu::StoreOp::Clear,
+                        clear_value: 0,
+                        read_only: false,
+                    },
                 }),
             });
             pass.set_pipeline(&self.forward_pass.pipeline);

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -756,18 +756,11 @@ impl framework::Example for Example {
                 color_attachments: &[],
                 depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachmentDescriptor {
                     attachment: &light.target_view,
-                    depth: wgpu::PassChannel {
-                        load_op: wgpu::LoadOp::Clear,
-                        store_op: wgpu::StoreOp::Store,
-                        clear_value: 1.0,
-                        read_only: false,
-                    },
-                    stencil: wgpu::PassChannel {
-                        load_op: wgpu::LoadOp::Clear,
-                        store_op: wgpu::StoreOp::Store,
-                        clear_value: 0,
-                        read_only: false,
-                    },
+                    depth_ops: Some(wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(1.0),
+                        store: true,
+                    }),
+                    stencil_ops: None,
                 }),
             });
             pass.set_pipeline(&self.shadow_pass.pipeline);
@@ -787,32 +780,23 @@ impl framework::Example for Example {
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,
-                    channel: wgpu::PassChannel {
-                        load_op: wgpu::LoadOp::Clear,
-                        store_op: wgpu::StoreOp::Store,
-                        clear_value: wgpu::Color {
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color {
                             r: 0.1,
                             g: 0.2,
                             b: 0.3,
                             a: 1.0,
-                        },
-                        read_only: false,
+                        }),
+                        store: true,
                     },
                 }],
                 depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachmentDescriptor {
                     attachment: &self.forward_depth,
-                    depth: wgpu::PassChannel {
-                        load_op: wgpu::LoadOp::Clear,
-                        store_op: wgpu::StoreOp::Clear,
-                        clear_value: 1.0,
-                        read_only: false,
-                    },
-                    stencil: wgpu::PassChannel {
-                        load_op: wgpu::LoadOp::Clear,
-                        store_op: wgpu::StoreOp::Clear,
-                        clear_value: 0,
-                        read_only: false,
-                    },
+                    depth_ops: Some(wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(1.0),
+                        store: false,
+                    }),
+                    stencil_ops: None,
                 }),
             });
             pass.set_pipeline(&self.forward_pass.pipeline);

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -278,13 +278,16 @@ impl framework::Example for Skybox {
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,
-                    load_op: wgpu::LoadOp::Clear,
-                    store_op: wgpu::StoreOp::Store,
-                    clear_color: wgpu::Color {
-                        r: 0.1,
-                        g: 0.2,
-                        b: 0.3,
-                        a: 1.0,
+                    channel: wgpu::PassChannel {
+                        load_op: wgpu::LoadOp::Clear,
+                        store_op: wgpu::StoreOp::Store,
+                        clear_value: wgpu::Color {
+                            r: 0.1,
+                            g: 0.2,
+                            b: 0.3,
+                            a: 1.0,
+                        },
+                        read_only: false,
                     },
                 }],
                 depth_stencil_attachment: None,

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -278,16 +278,14 @@ impl framework::Example for Skybox {
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,
-                    channel: wgpu::PassChannel {
-                        load_op: wgpu::LoadOp::Clear,
-                        store_op: wgpu::StoreOp::Store,
-                        clear_value: wgpu::Color {
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color {
                             r: 0.1,
                             g: 0.2,
                             b: 0.3,
                             a: 1.0,
-                        },
-                        read_only: false,
+                        }),
+                        store: true,
                     },
                 }],
                 depth_stencil_attachment: None,

--- a/examples/texture-arrays/main.rs
+++ b/examples/texture-arrays/main.rs
@@ -371,11 +371,9 @@ impl framework::Example for Example {
             color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                 attachment: &frame.view,
                 resolve_target: None,
-                channel: wgpu::PassChannel {
-                    load_op: wgpu::LoadOp::Clear,
-                    store_op: wgpu::StoreOp::Store,
-                    clear_value: wgpu::Color::BLACK,
-                    read_only: false,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                    store: true,
                 },
             }],
             depth_stencil_attachment: None,

--- a/examples/texture-arrays/main.rs
+++ b/examples/texture-arrays/main.rs
@@ -371,13 +371,11 @@ impl framework::Example for Example {
             color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                 attachment: &frame.view,
                 resolve_target: None,
-                load_op: wgpu::LoadOp::Clear,
-                store_op: wgpu::StoreOp::Store,
-                clear_color: wgpu::Color {
-                    r: 0.0,
-                    g: 0.0,
-                    b: 0.0,
-                    a: 1.0,
+                channel: wgpu::PassChannel {
+                    load_op: wgpu::LoadOp::Clear,
+                    store_op: wgpu::StoreOp::Store,
+                    clear_value: wgpu::Color::BLACK,
+                    read_only: false,
                 },
             }],
             depth_stencil_attachment: None,

--- a/examples/water/main.rs
+++ b/examples/water/main.rs
@@ -358,11 +358,9 @@ impl framework::Example for Example {
                         wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
                         wgpu::BindingType::UniformBuffer {
                             dynamic: false,
-                            min_binding_size: wgpu::NonZeroBufferAddress::new(mem::size_of::<
-                                WaterUniforms,
-                            >(
-                            )
-                                as _),
+                            min_binding_size: wgpu::BufferSize::new(
+                                mem::size_of::<WaterUniforms>() as _,
+                            ),
                         },
                     ),
                     // Reflection texture.
@@ -404,11 +402,9 @@ impl framework::Example for Example {
                         wgpu::ShaderStage::VERTEX,
                         wgpu::BindingType::UniformBuffer {
                             dynamic: false,
-                            min_binding_size: wgpu::NonZeroBufferAddress::new(mem::size_of::<
-                                TerrainUniforms,
-                            >(
-                            )
-                                as _),
+                            min_binding_size: wgpu::BufferSize::new(
+                                mem::size_of::<TerrainUniforms>() as _,
+                            ),
                         },
                     ),
                 ],
@@ -687,6 +683,12 @@ impl framework::Example for Example {
     ) -> wgpu::CommandBuffer {
         // Increment frame count regardless of if we draw.
         self.current_frame += 1;
+        let back_color = wgpu::Color {
+            r: 161.0 / 255.0,
+            g: 246.0 / 255.0,
+            b: 255.0 / 255.0,
+            a: 1.0,
+        };
 
         // Write the sin/cos values to the uniform buffer for the water.
         let (water_sin, water_cos) = ((self.current_frame as f32) / 600.0).sin_cos();
@@ -717,27 +719,29 @@ impl framework::Example for Example {
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &self.reflect_view,
                     resolve_target: None,
-                    load_op: wgpu::LoadOp::Clear,
-                    store_op: wgpu::StoreOp::Store,
-                    clear_color: wgpu::Color {
-                        r: 161.0 / 255.0,
-                        g: 246.0 / 255.0,
-                        b: 255.0 / 255.0,
-                        a: 1.0,
+                    channel: wgpu::PassChannel {
+                        load_op: wgpu::LoadOp::Clear,
+                        store_op: wgpu::StoreOp::Store,
+                        clear_value: back_color,
+                        read_only: false,
                     },
                 }],
                 // We still need to use the depth buffer here
                 // since the pipeline requires it.
                 depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachmentDescriptor {
                     attachment: &self.depth_buffer,
-                    depth_load_op: wgpu::LoadOp::Clear,
-                    depth_store_op: wgpu::StoreOp::Clear,
-                    clear_depth: 1.0,
-                    depth_read_only: false,
-                    stencil_load_op: wgpu::LoadOp::Clear,
-                    stencil_store_op: wgpu::StoreOp::Store,
-                    clear_stencil: 0,
-                    stencil_read_only: false,
+                    depth: wgpu::PassChannel {
+                        load_op: wgpu::LoadOp::Clear,
+                        store_op: wgpu::StoreOp::Clear,
+                        clear_value: 1.0,
+                        read_only: false,
+                    },
+                    stencil: wgpu::PassChannel {
+                        load_op: wgpu::LoadOp::Clear,
+                        store_op: wgpu::StoreOp::Clear,
+                        clear_value: 0,
+                        read_only: false,
+                    },
                 }),
             });
             rpass.set_pipeline(&self.terrain_pipeline);
@@ -752,25 +756,27 @@ impl framework::Example for Example {
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,
-                    load_op: wgpu::LoadOp::Clear,
-                    store_op: wgpu::StoreOp::Store,
-                    clear_color: wgpu::Color {
-                        r: 161.0 / 255.0,
-                        g: 246.0 / 255.0,
-                        b: 255.0 / 255.0,
-                        a: 1.0,
+                    channel: wgpu::PassChannel {
+                        load_op: wgpu::LoadOp::Clear,
+                        store_op: wgpu::StoreOp::Store,
+                        clear_value: back_color,
+                        read_only: false,
                     },
                 }],
                 depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachmentDescriptor {
                     attachment: &self.depth_buffer,
-                    depth_load_op: wgpu::LoadOp::Clear,
-                    depth_store_op: wgpu::StoreOp::Store,
-                    clear_depth: 1.0,
-                    depth_read_only: false,
-                    stencil_load_op: wgpu::LoadOp::Clear,
-                    stencil_store_op: wgpu::StoreOp::Store,
-                    clear_stencil: 0,
-                    stencil_read_only: false,
+                    depth: wgpu::PassChannel {
+                        load_op: wgpu::LoadOp::Clear,
+                        store_op: wgpu::StoreOp::Store,
+                        clear_value: 1.0,
+                        read_only: false,
+                    },
+                    stencil: wgpu::PassChannel {
+                        load_op: wgpu::LoadOp::Clear,
+                        store_op: wgpu::StoreOp::Store,
+                        clear_value: 0,
+                        read_only: false,
+                    },
                 }),
             });
             rpass.set_pipeline(&self.terrain_pipeline);
@@ -785,25 +791,27 @@ impl framework::Example for Example {
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,
-                    load_op: wgpu::LoadOp::Load,
-                    store_op: wgpu::StoreOp::Store,
-                    clear_color: wgpu::Color {
-                        r: 161.0 / 255.0,
-                        g: 246.0 / 255.0,
-                        b: 255.0 / 255.0,
-                        a: 1.0,
+                    channel: wgpu::PassChannel {
+                        load_op: wgpu::LoadOp::Load,
+                        store_op: wgpu::StoreOp::Store,
+                        clear_value: back_color,
+                        read_only: false,
                     },
                 }],
                 depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachmentDescriptor {
                     attachment: &self.depth_buffer,
-                    depth_load_op: wgpu::LoadOp::Load,
-                    depth_store_op: wgpu::StoreOp::Store,
-                    clear_depth: 1.0,
-                    depth_read_only: true,
-                    stencil_load_op: wgpu::LoadOp::Load,
-                    stencil_store_op: wgpu::StoreOp::Store,
-                    clear_stencil: 0,
-                    stencil_read_only: false,
+                    depth: wgpu::PassChannel {
+                        load_op: wgpu::LoadOp::Load,
+                        store_op: wgpu::StoreOp::Store,
+                        clear_value: 1.0,
+                        read_only: true,
+                    },
+                    stencil: wgpu::PassChannel {
+                        load_op: wgpu::LoadOp::Load,
+                        store_op: wgpu::StoreOp::Store,
+                        clear_value: 0,
+                        read_only: false,
+                    },
                 }),
             });
 

--- a/examples/water/main.rs
+++ b/examples/water/main.rs
@@ -719,29 +719,20 @@ impl framework::Example for Example {
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &self.reflect_view,
                     resolve_target: None,
-                    channel: wgpu::PassChannel {
-                        load_op: wgpu::LoadOp::Clear,
-                        store_op: wgpu::StoreOp::Store,
-                        clear_value: back_color,
-                        read_only: false,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(back_color),
+                        store: true,
                     },
                 }],
                 // We still need to use the depth buffer here
                 // since the pipeline requires it.
                 depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachmentDescriptor {
                     attachment: &self.depth_buffer,
-                    depth: wgpu::PassChannel {
-                        load_op: wgpu::LoadOp::Clear,
-                        store_op: wgpu::StoreOp::Clear,
-                        clear_value: 1.0,
-                        read_only: false,
-                    },
-                    stencil: wgpu::PassChannel {
-                        load_op: wgpu::LoadOp::Clear,
-                        store_op: wgpu::StoreOp::Clear,
-                        clear_value: 0,
-                        read_only: false,
-                    },
+                    depth_ops: Some(wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(1.0),
+                        store: true,
+                    }),
+                    stencil_ops: None,
                 }),
             });
             rpass.set_pipeline(&self.terrain_pipeline);
@@ -756,27 +747,18 @@ impl framework::Example for Example {
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,
-                    channel: wgpu::PassChannel {
-                        load_op: wgpu::LoadOp::Clear,
-                        store_op: wgpu::StoreOp::Store,
-                        clear_value: back_color,
-                        read_only: false,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(back_color),
+                        store: true,
                     },
                 }],
                 depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachmentDescriptor {
                     attachment: &self.depth_buffer,
-                    depth: wgpu::PassChannel {
-                        load_op: wgpu::LoadOp::Clear,
-                        store_op: wgpu::StoreOp::Store,
-                        clear_value: 1.0,
-                        read_only: false,
-                    },
-                    stencil: wgpu::PassChannel {
-                        load_op: wgpu::LoadOp::Clear,
-                        store_op: wgpu::StoreOp::Store,
-                        clear_value: 0,
-                        read_only: false,
-                    },
+                    depth_ops: Some(wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(1.0),
+                        store: true,
+                    }),
+                    stencil_ops: None,
                 }),
             });
             rpass.set_pipeline(&self.terrain_pipeline);
@@ -791,27 +773,15 @@ impl framework::Example for Example {
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,
-                    channel: wgpu::PassChannel {
-                        load_op: wgpu::LoadOp::Load,
-                        store_op: wgpu::StoreOp::Store,
-                        clear_value: back_color,
-                        read_only: false,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: true,
                     },
                 }],
                 depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachmentDescriptor {
                     attachment: &self.depth_buffer,
-                    depth: wgpu::PassChannel {
-                        load_op: wgpu::LoadOp::Load,
-                        store_op: wgpu::StoreOp::Store,
-                        clear_value: 1.0,
-                        read_only: true,
-                    },
-                    stencil: wgpu::PassChannel {
-                        load_op: wgpu::LoadOp::Load,
-                        store_op: wgpu::StoreOp::Store,
-                        clear_value: 0,
-                        read_only: false,
-                    },
+                    depth_ops: None,
+                    stencil_ops: None,
                 }),
             });
 

--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -36,9 +36,9 @@ mod pass_impl {
     use std::ops::Range;
     use wgc::command::{bundle_ffi::*, compute_ffi::*, render_ffi::*};
 
-    impl crate::ComputePassInner<Context> for wgc::command::RawPass<wgc::id::CommandEncoderId> {
+    impl crate::ComputePassInner<Context> for wgc::command::ComputePass {
         fn set_pipeline(&mut self, pipeline: &wgc::id::ComputePipelineId) {
-            unsafe { wgpu_compute_pass_set_pipeline(self, *pipeline) }
+            wgpu_compute_pass_set_pipeline(self, *pipeline)
         }
         fn set_bind_group(
             &mut self,
@@ -57,20 +57,20 @@ mod pass_impl {
             }
         }
         fn dispatch(&mut self, x: u32, y: u32, z: u32) {
-            unsafe { wgpu_compute_pass_dispatch(self, x, y, z) }
+            wgpu_compute_pass_dispatch(self, x, y, z)
         }
         fn dispatch_indirect(
             &mut self,
             indirect_buffer: &wgc::id::BufferId,
             indirect_offset: wgt::BufferAddress,
         ) {
-            unsafe { wgpu_compute_pass_dispatch_indirect(self, *indirect_buffer, indirect_offset) }
+            wgpu_compute_pass_dispatch_indirect(self, *indirect_buffer, indirect_offset)
         }
     }
 
-    impl crate::RenderInner<Context> for wgc::command::RawPass<wgc::id::CommandEncoderId> {
+    impl crate::RenderInner<Context> for wgc::command::RenderPass {
         fn set_pipeline(&mut self, pipeline: &wgc::id::RenderPipelineId) {
-            unsafe { wgpu_render_pass_set_pipeline(self, *pipeline) }
+            wgpu_render_pass_set_pipeline(self, *pipeline)
         }
         fn set_bind_group(
             &mut self,
@@ -92,66 +92,60 @@ mod pass_impl {
             &mut self,
             buffer: &wgc::id::BufferId,
             offset: wgt::BufferAddress,
-            size: wgt::BufferSize,
+            size: Option<wgt::BufferSize>,
         ) {
-            unsafe { wgpu_render_pass_set_index_buffer(self, *buffer, offset, size) }
+            wgpu_render_pass_set_index_buffer(self, *buffer, offset, size)
         }
         fn set_vertex_buffer(
             &mut self,
             slot: u32,
             buffer: &wgc::id::BufferId,
             offset: wgt::BufferAddress,
-            size: wgt::BufferSize,
+            size: Option<wgt::BufferSize>,
         ) {
-            unsafe { wgpu_render_pass_set_vertex_buffer(self, slot, *buffer, offset, size) }
+            wgpu_render_pass_set_vertex_buffer(self, slot, *buffer, offset, size)
         }
         fn draw(&mut self, vertices: Range<u32>, instances: Range<u32>) {
-            unsafe {
-                wgpu_render_pass_draw(
-                    self,
-                    vertices.end - vertices.start,
-                    instances.end - instances.start,
-                    vertices.start,
-                    instances.start,
-                )
-            }
+            wgpu_render_pass_draw(
+                self,
+                vertices.end - vertices.start,
+                instances.end - instances.start,
+                vertices.start,
+                instances.start,
+            )
         }
         fn draw_indexed(&mut self, indices: Range<u32>, base_vertex: i32, instances: Range<u32>) {
-            unsafe {
-                wgpu_render_pass_draw_indexed(
-                    self,
-                    indices.end - indices.start,
-                    instances.end - instances.start,
-                    indices.start,
-                    base_vertex,
-                    instances.start,
-                )
-            }
+            wgpu_render_pass_draw_indexed(
+                self,
+                indices.end - indices.start,
+                instances.end - instances.start,
+                indices.start,
+                base_vertex,
+                instances.start,
+            )
         }
         fn draw_indirect(
             &mut self,
             indirect_buffer: &wgc::id::BufferId,
             indirect_offset: wgt::BufferAddress,
         ) {
-            unsafe { wgpu_render_pass_draw_indirect(self, *indirect_buffer, indirect_offset) }
+            wgpu_render_pass_draw_indirect(self, *indirect_buffer, indirect_offset)
         }
         fn draw_indexed_indirect(
             &mut self,
             indirect_buffer: &wgc::id::BufferId,
             indirect_offset: wgt::BufferAddress,
         ) {
-            unsafe {
-                wgpu_render_pass_draw_indexed_indirect(self, *indirect_buffer, indirect_offset)
-            }
+            wgpu_render_pass_draw_indexed_indirect(self, *indirect_buffer, indirect_offset)
         }
     }
 
-    impl crate::RenderPassInner<Context> for wgc::command::RawPass<wgc::id::CommandEncoderId> {
+    impl crate::RenderPassInner<Context> for wgc::command::RenderPass {
         fn set_blend_color(&mut self, color: wgt::Color) {
-            unsafe { wgpu_render_pass_set_blend_color(self, &color) }
+            wgpu_render_pass_set_blend_color(self, &color)
         }
         fn set_scissor_rect(&mut self, x: u32, y: u32, width: u32, height: u32) {
-            unsafe { wgpu_render_pass_set_scissor_rect(self, x, y, width, height) }
+            wgpu_render_pass_set_scissor_rect(self, x, y, width, height)
         }
         fn set_viewport(
             &mut self,
@@ -162,12 +156,10 @@ mod pass_impl {
             min_depth: f32,
             max_depth: f32,
         ) {
-            unsafe {
-                wgpu_render_pass_set_viewport(self, x, y, width, height, min_depth, max_depth)
-            }
+            wgpu_render_pass_set_viewport(self, x, y, width, height, min_depth, max_depth)
         }
         fn set_stencil_reference(&mut self, reference: u32) {
-            unsafe { wgpu_render_pass_set_stencil_reference(self, reference) }
+            wgpu_render_pass_set_stencil_reference(self, reference)
         }
 
         fn insert_debug_marker(&mut self, label: &str) {
@@ -185,9 +177,7 @@ mod pass_impl {
         }
 
         fn pop_debug_group(&mut self) {
-            unsafe {
-                wgpu_render_pass_pop_debug_group(self);
-            }
+            wgpu_render_pass_pop_debug_group(self);
         }
 
         fn execute_bundles<'a, I: Iterator<Item = &'a wgc::id::RenderBundleId>>(
@@ -207,7 +197,7 @@ mod pass_impl {
 
     impl crate::RenderInner<Context> for wgc::command::RenderBundleEncoder {
         fn set_pipeline(&mut self, pipeline: &wgc::id::RenderPipelineId) {
-            unsafe { wgpu_render_bundle_set_pipeline(self, *pipeline) }
+            wgpu_render_bundle_set_pipeline(self, *pipeline)
         }
         fn set_bind_group(
             &mut self,
@@ -229,57 +219,51 @@ mod pass_impl {
             &mut self,
             buffer: &wgc::id::BufferId,
             offset: wgt::BufferAddress,
-            size: wgt::BufferSize,
+            size: Option<wgt::BufferSize>,
         ) {
-            unsafe { wgpu_render_bundle_set_index_buffer(self, *buffer, offset, size) }
+            wgpu_render_bundle_set_index_buffer(self, *buffer, offset, size)
         }
         fn set_vertex_buffer(
             &mut self,
             slot: u32,
             buffer: &wgc::id::BufferId,
             offset: wgt::BufferAddress,
-            size: wgt::BufferSize,
+            size: Option<wgt::BufferSize>,
         ) {
-            unsafe { wgpu_render_bundle_set_vertex_buffer(self, slot, *buffer, offset, size) }
+            wgpu_render_bundle_set_vertex_buffer(self, slot, *buffer, offset, size)
         }
         fn draw(&mut self, vertices: Range<u32>, instances: Range<u32>) {
-            unsafe {
-                wgpu_render_bundle_draw(
-                    self,
-                    vertices.end - vertices.start,
-                    instances.end - instances.start,
-                    vertices.start,
-                    instances.start,
-                )
-            }
+            wgpu_render_bundle_draw(
+                self,
+                vertices.end - vertices.start,
+                instances.end - instances.start,
+                vertices.start,
+                instances.start,
+            )
         }
         fn draw_indexed(&mut self, indices: Range<u32>, base_vertex: i32, instances: Range<u32>) {
-            unsafe {
-                wgpu_render_bundle_draw_indexed(
-                    self,
-                    indices.end - indices.start,
-                    instances.end - instances.start,
-                    indices.start,
-                    base_vertex,
-                    instances.start,
-                )
-            }
+            wgpu_render_bundle_draw_indexed(
+                self,
+                indices.end - indices.start,
+                instances.end - instances.start,
+                indices.start,
+                base_vertex,
+                instances.start,
+            )
         }
         fn draw_indirect(
             &mut self,
             indirect_buffer: &wgc::id::BufferId,
             indirect_offset: wgt::BufferAddress,
         ) {
-            unsafe { wgpu_render_bundle_draw_indirect(self, *indirect_buffer, indirect_offset) }
+            wgpu_render_bundle_draw_indirect(self, *indirect_buffer, indirect_offset)
         }
         fn draw_indexed_indirect(
             &mut self,
             indirect_buffer: &wgc::id::BufferId,
             indirect_offset: wgt::BufferAddress,
         ) {
-            unsafe {
-                wgpu_render_pass_bundle_indexed_indirect(self, *indirect_buffer, indirect_offset)
-            }
+            wgpu_render_pass_bundle_indexed_indirect(self, *indirect_buffer, indirect_offset)
         }
     }
 }
@@ -314,8 +298,8 @@ impl crate::Context for Context {
     type RenderPipelineId = wgc::id::RenderPipelineId;
     type ComputePipelineId = wgc::id::ComputePipelineId;
     type CommandEncoderId = wgc::id::CommandEncoderId;
-    type ComputePassId = wgc::command::RawPass<wgc::id::CommandEncoderId>;
-    type RenderPassId = wgc::command::RawPass<wgc::id::CommandEncoderId>;
+    type ComputePassId = wgc::command::ComputePass;
+    type RenderPassId = wgc::command::RenderPass;
     type CommandBufferId = wgc::id::CommandBufferId;
     type RenderBundleEncoderId = wgc::command::RenderBundleEncoder;
     type RenderBundleId = wgc::id::RenderBundleId;
@@ -469,7 +453,7 @@ impl crate::Context for Context {
                 bindings: &bindings,
             },
             PhantomData
-        ))
+        )).unwrap()
     }
 
     fn device_create_pipeline_layout(
@@ -647,7 +631,7 @@ impl crate::Context for Context {
         device: &Self::DeviceId,
         desc: &wgt::RenderBundleEncoderDescriptor,
     ) -> Self::RenderBundleEncoderId {
-        wgc::command::RenderBundleEncoder::new(desc, *device)
+        wgc::command::RenderBundleEncoder::new(desc, *device, None)
     }
 
     fn device_drop(&self, device: &Self::DeviceId) {
@@ -711,7 +695,7 @@ impl crate::Context for Context {
         let ptr = gfx_select!(*buffer => self.buffer_get_mapped_range(
             *buffer,
             sub_range.start,
-            wgt::BufferSize(size)
+            wgt::BufferSize::new(size)
         ));
         unsafe { slice::from_raw_parts(ptr, size as usize) }
     }
@@ -725,7 +709,7 @@ impl crate::Context for Context {
         let ptr = gfx_select!(*buffer => self.buffer_get_mapped_range(
             *buffer,
             sub_range.start,
-            wgt::BufferSize(size)
+            wgt::BufferSize::new(size)
         ));
         unsafe { slice::from_raw_parts_mut(ptr, size as usize) }
     }
@@ -873,7 +857,7 @@ impl crate::Context for Context {
         &self,
         encoder: &Self::CommandEncoderId,
     ) -> Self::ComputePassId {
-        unsafe { wgc::command::RawPass::new_compute(*encoder) }
+        wgc::command::ComputePass::new(*encoder)
     }
 
     fn command_encoder_end_compute_pass(
@@ -881,13 +865,7 @@ impl crate::Context for Context {
         encoder: &Self::CommandEncoderId,
         pass: &mut Self::ComputePassId,
     ) {
-        let data = unsafe {
-            let mut length = 0;
-            let ptr = wgc::command::compute_ffi::wgpu_compute_pass_finish(pass, &mut length);
-            slice::from_raw_parts(ptr, length)
-        };
-        gfx_select!(*encoder => self.command_encoder_run_compute_pass(*encoder, data));
-        unsafe { pass.invalidate() };
+        gfx_select!(*encoder => self.command_encoder_run_compute_pass(*encoder, pass));
     }
 
     fn command_encoder_begin_render_pass<'a>(
@@ -898,39 +876,28 @@ impl crate::Context for Context {
         let colors = desc
             .color_attachments
             .iter()
-            .map(|ca| wgc::command::RenderPassColorAttachmentDescriptor {
+            .map(|ca| wgc::command::ColorAttachmentDescriptor {
                 attachment: ca.attachment.id,
                 resolve_target: ca.resolve_target.map(|rt| rt.id),
-                load_op: ca.load_op,
-                store_op: ca.store_op,
-                clear_color: ca.clear_color,
+                channel: ca.channel.clone(),
             })
-            .collect::<ArrayVec<[_; 4]>>();
+            .collect::<ArrayVec<[_; wgc::device::MAX_COLOR_TARGETS]>>();
 
         let depth_stencil = desc.depth_stencil_attachment.as_ref().map(|dsa| {
-            wgc::command::RenderPassDepthStencilAttachmentDescriptor {
+            wgc::command::DepthStencilAttachmentDescriptor {
                 attachment: dsa.attachment.id,
-                depth_load_op: dsa.depth_load_op,
-                depth_store_op: dsa.depth_store_op,
-                depth_read_only: dsa.depth_read_only,
-                clear_depth: dsa.clear_depth,
-                stencil_load_op: dsa.stencil_load_op,
-                stencil_store_op: dsa.stencil_store_op,
-                clear_stencil: dsa.clear_stencil,
-                stencil_read_only: dsa.depth_read_only,
+                depth: dsa.depth.clone(),
+                stencil: dsa.stencil.clone(),
             }
         });
 
-        unsafe {
-            wgc::command::RawPass::new_render(
-                *encoder,
-                &wgc::command::RenderPassDescriptor {
-                    color_attachments: colors.as_ptr(),
-                    color_attachments_length: colors.len(),
-                    depth_stencil_attachment: depth_stencil.as_ref(),
-                },
-            )
-        }
+        wgc::command::RenderPass::new(
+            *encoder,
+            wgc::command::RenderPassDescriptor {
+                color_attachments: &colors,
+                depth_stencil_attachment: depth_stencil.as_ref(),
+            },
+        )
     }
 
     fn command_encoder_end_render_pass(
@@ -938,13 +905,7 @@ impl crate::Context for Context {
         encoder: &Self::CommandEncoderId,
         pass: &mut Self::RenderPassId,
     ) {
-        let data = unsafe {
-            let mut length = 0;
-            let ptr = wgc::command::render_ffi::wgpu_render_pass_finish(pass, &mut length);
-            slice::from_raw_parts(ptr, length)
-        };
-        gfx_select!(*encoder => self.command_encoder_run_render_pass(*encoder, data));
-        unsafe { pass.invalidate() };
+        gfx_select!(*encoder => self.command_encoder_run_render_pass(*encoder, pass));
     }
 
     fn command_encoder_finish(&self, encoder: &Self::CommandEncoderId) -> Self::CommandBufferId {
@@ -958,7 +919,11 @@ impl crate::Context for Context {
         desc: &crate::RenderBundleDescriptor,
     ) -> Self::RenderBundleId {
         let owned_label = OwnedLabel::new(desc.label.as_deref());
-        gfx_select!(encoder.parent() => self.render_bundle_encoder_finish(encoder, &desc.map_label(|_| owned_label.as_ptr()), PhantomData))
+        gfx_select!(encoder.parent() => self.render_bundle_encoder_finish(
+            encoder,
+            &desc.map_label(|_| owned_label.as_ptr()),
+            PhantomData
+        ))
     }
 
     fn queue_write_buffer(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,12 +25,12 @@ pub use wgt::{
     BlendDescriptor, BlendFactor, BlendOperation, BufferAddress, BufferSize, BufferUsage,
     Capabilities, Color, ColorStateDescriptor, ColorWrite, CommandBufferDescriptor,
     CompareFunction, CullMode, DepthStencilStateDescriptor, DeviceDescriptor, DynamicOffset,
-    Extensions, Extent3d, FilterMode, FrontFace, IndexFormat, InputStepMode, Limits, LoadOp,
-    Origin3d, PassChannel, PowerPreference, PresentMode, PrimitiveTopology,
-    RasterizationStateDescriptor, RenderBundleEncoderDescriptor, ShaderLocation, ShaderStage,
-    StencilOperation, StencilStateFaceDescriptor, StoreOp, SwapChainDescriptor, SwapChainStatus,
-    TextureAspect, TextureComponentType, TextureDataLayout, TextureDimension, TextureFormat,
-    TextureUsage, TextureViewDimension, UnsafeExtensions, VertexAttributeDescriptor, VertexFormat,
+    Extensions, Extent3d, FilterMode, FrontFace, IndexFormat, InputStepMode, Limits, Origin3d,
+    PowerPreference, PresentMode, PrimitiveTopology, RasterizationStateDescriptor,
+    RenderBundleEncoderDescriptor, ShaderLocation, ShaderStage, StencilOperation,
+    StencilStateFaceDescriptor, SwapChainDescriptor, SwapChainStatus, TextureAspect,
+    TextureComponentType, TextureDataLayout, TextureDimension, TextureFormat, TextureUsage,
+    TextureViewDimension, UnsafeExtensions, VertexAttributeDescriptor, VertexFormat,
     BIND_BUFFER_ALIGNMENT, COPY_BUFFER_ALIGNMENT, COPY_BYTES_PER_ROW_ALIGNMENT,
 };
 
@@ -892,18 +892,39 @@ pub struct ComputePipelineDescriptor<'a> {
     pub compute_stage: ProgrammableStageDescriptor<'a>,
 }
 
-// The underlying types are also exported so that documentation shows up for them
+/// Operation to perform to the output attachment at the start of a renderpass.
+#[derive(Clone, Copy, Debug, Hash, PartialEq)]
+pub enum LoadOp<V> {
+    /// Clear with a specified value.
+    Clear(V),
+    /// Load from memory.
+    Load,
+}
 
-pub use wgt::RenderPassColorAttachmentDescriptorBase;
+/// Pair of load and store operations for an attachment aspect.
+#[derive(Clone, Debug, Hash, PartialEq)]
+pub struct Operations<V> {
+    pub load: LoadOp<V>,
+    pub store: bool,
+}
+
 /// Describes a color attachment to a [`RenderPass`].
-pub type RenderPassColorAttachmentDescriptor<'a> =
-    wgt::RenderPassColorAttachmentDescriptorBase<&'a TextureView>;
-pub use wgt::RenderPassDepthStencilAttachmentDescriptorBase;
+#[derive(Clone)]
+pub struct RenderPassColorAttachmentDescriptor<'a> {
+    pub attachment: &'a TextureView,
+    pub resolve_target: Option<&'a TextureView>,
+    pub ops: Operations<Color>,
+}
 /// Describes a depth/stencil attachment to a [`RenderPass`].
-pub type RenderPassDepthStencilAttachmentDescriptor<'a> =
-    wgt::RenderPassDepthStencilAttachmentDescriptorBase<&'a TextureView>;
+#[derive(Clone)]
+pub struct RenderPassDepthStencilAttachmentDescriptor<'a> {
+    pub attachment: &'a TextureView,
+    pub depth_ops: Option<Operations<f32>>,
+    pub stencil_ops: Option<Operations<u32>>,
+}
 
 /// Describes the attachments of a [`RenderPass`].
+#[derive(Clone)]
 pub struct RenderPassDescriptor<'a, 'b> {
     /// The color attachments of the render pass.
     pub color_attachments: &'b [RenderPassColorAttachmentDescriptor<'a>],


### PR DESCRIPTION
Depends on https://github.com/gfx-rs/wgpu/pull/739
Everything works, however I think it's worth changing the render pass color/depth/stencil descriptors to be more rusty, e.g.
```rust
struct ColorAttachmentDescriptor {
  attachment: &'a TextureView,
  resolve_target: Option<&'a TextureView>,
  clear_color: Option<Color>,
  store_result: bool,
}

enum DepthStencilChannel<T> {
  ReadOnly,
  Mutable { clear_value: Option<T>, store_result: bool },
}
struct DepthStencilAttachmentDescriptor {
}
```
This would also involve wgpu-type/wgpu-core changes, but can be done as a follow-up (don't want to block on them).

There is a value in doing it in this PR, so that end users don't get multiple disruptions, but we need to find a proper shape first.