### PR TITLE
Fix the mipmap example

### DIFF
--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -304,6 +304,7 @@ impl framework::Example for Example {
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Linear,
             mipmap_filter: wgpu::FilterMode::Linear,
+            lod_max_clamp: f32::MAX,
             ..Default::default()
         });
         let mx_total = Self::generate_matrix(sc_desc.width as f32 / sc_desc.height as f32);


### PR DESCRIPTION
The current default value for the lod_max_clamp of a sampler is 0.
This would deactivate mipmaping all together. Setting it to
f32::MAX makes sure to always enable it. It's the default value apple
uses in Metal, it seems to be valid usage in Vulkan (maxLod in
VkSamplerCreateInfo) and in DX12 (MaxLOD in D3D12_SAMPLER_DESC).

Before:
![broken](https://user-images.githubusercontent.com/12084860/85195803-dcc68f80-b2d5-11ea-9273-57f80702cca8.jpg)

After:
![fixed](https://user-images.githubusercontent.com/12084860/85195808-df28e980-b2d5-11ea-9d73-4888f55563ad.jpg)
