### PR TITLE
Re-enable auto-deploy from gecko branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     branches:
-      - master-TEMPORARILY-DISABLED
+      - gecko
 
 env:
   RUSTFLAGS: --cfg=web_sys_unstable_apis


### PR DESCRIPTION
As mentioned on Matrix, the `gecko` branch should be safe to use for auto-deployment to GitHub pages for the wgpu-rs examples on wasm.

We can use the `gecko` branch for now and eventually switch back to `master`.