### PR TITLE
Add a link to https://wgpu.rs/doc/wgpu/

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,10 @@
                 <a href="https://crates.io/crates/wgpu"> Crates.io </a>
             </li>
             <li> 
-                <a href="https://docs.rs/wgpu/"> Documentation </a> 
+                <a href="https://docs.rs/wgpu/"> Documentation (released versions)</a>
+            </li>
+            <li> 
+                <a href="https://wgpu.rs/doc/wgpu/"> Documentation (latest GitHub master)</a>
             </li>
             <li> 
                 <a href="./examples/index.html" title="Requires Firefox Nightly or Chrome Canary"> Live Examples </a> 


### PR DESCRIPTION
Though now the doc is built thanks to #389, it seems there's no link to it. I'm not sure what wording should be good, but I quickly added a link. Maybe README should also have a link...?