### PR TITLE
Implement MultiDrawIndirect Extensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ vulkan = ["wgc/gfx-backend-vulkan"]
 package = "wgpu-core"
 version = "0.5"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "3b6e128877d74f8310967e377c5193fd4105ee13"
+rev = "43c67ac59c2dedaa4d78601bc460aab7c3257973"
 features = ["raw-window-handle"]
 
 [dependencies.wgt]
 package = "wgpu-types"
 version = "0.5"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "3b6e128877d74f8310967e377c5193fd4105ee13"
+rev = "43c67ac59c2dedaa4d78601bc460aab7c3257973"
 
 [dependencies]
 arrayvec = "0.5"

--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -138,6 +138,61 @@ mod pass_impl {
         ) {
             wgpu_render_pass_draw_indexed_indirect(self, *indirect_buffer, indirect_offset)
         }
+        fn multi_draw_indirect(
+            &mut self,
+            indirect_buffer: &wgc::id::BufferId,
+            indirect_offset: wgt::BufferAddress,
+            count: u32,
+        ) {
+            wgpu_render_pass_multi_draw_indirect(self, *indirect_buffer, indirect_offset, count)
+        }
+        fn multi_draw_indexed_indirect(
+            &mut self,
+            indirect_buffer: &wgc::id::BufferId,
+            indirect_offset: wgt::BufferAddress,
+            count: u32,
+        ) {
+            wgpu_render_pass_multi_draw_indexed_indirect(
+                self,
+                *indirect_buffer,
+                indirect_offset,
+                count,
+            )
+        }
+        fn multi_draw_indirect_count(
+            &mut self,
+            indirect_buffer: &wgc::id::BufferId,
+            indirect_offset: wgt::BufferAddress,
+            count_buffer: &wgc::id::BufferId,
+            count_buffer_offset: wgt::BufferAddress,
+            max_count: u32,
+        ) {
+            wgpu_render_pass_multi_draw_indirect_count(
+                self,
+                *indirect_buffer,
+                indirect_offset,
+                *count_buffer,
+                count_buffer_offset,
+                max_count,
+            )
+        }
+        fn multi_draw_indexed_indirect_count(
+            &mut self,
+            indirect_buffer: &wgc::id::BufferId,
+            indirect_offset: wgt::BufferAddress,
+            count_buffer: &wgc::id::BufferId,
+            count_buffer_offset: wgt::BufferAddress,
+            max_count: u32,
+        ) {
+            wgpu_render_pass_multi_draw_indexed_indirect_count(
+                self,
+                *indirect_buffer,
+                indirect_offset,
+                *count_buffer,
+                count_buffer_offset,
+                max_count,
+            )
+        }
     }
 
     impl crate::RenderPassInner<Context> for wgc::command::RenderPass {
@@ -265,6 +320,42 @@ mod pass_impl {
             indirect_offset: wgt::BufferAddress,
         ) {
             wgpu_render_pass_bundle_indexed_indirect(self, *indirect_buffer, indirect_offset)
+        }
+        fn multi_draw_indirect(
+            &mut self,
+            _indirect_buffer: &wgc::id::BufferId,
+            _indirect_offset: wgt::BufferAddress,
+            _count: u32,
+        ) {
+            unimplemented!()
+        }
+        fn multi_draw_indexed_indirect(
+            &mut self,
+            _indirect_buffer: &wgc::id::BufferId,
+            _indirect_offset: wgt::BufferAddress,
+            _count: u32,
+        ) {
+            unimplemented!()
+        }
+        fn multi_draw_indirect_count(
+            &mut self,
+            _indirect_buffer: &wgc::id::BufferId,
+            _indirect_offset: wgt::BufferAddress,
+            _count_buffer: &wgc::id::BufferId,
+            _count_buffer_offset: wgt::BufferAddress,
+            _max_count: u32,
+        ) {
+            unimplemented!()
+        }
+        fn multi_draw_indexed_indirect_count(
+            &mut self,
+            _indirect_buffer: &wgc::id::BufferId,
+            _indirect_offset: wgt::BufferAddress,
+            _count_buffer: &wgc::id::BufferId,
+            _count_buffer_offset: wgt::BufferAddress,
+            _max_count: u32,
+        ) {
+            unimplemented!()
         }
     }
 }

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -164,6 +164,44 @@ impl crate::RenderInner<Context> for RenderPass {
         self.0
             .draw_indexed_indirect_with_f64(&indirect_buffer.0, indirect_offset as f64);
     }
+    fn multi_draw_indirect(
+        &mut self,
+        _indirect_buffer: &Sendable<web_sys::GpuBuffer>,
+        _indirect_offset: wgt::BufferAddress,
+        _count: u32,
+    ) {
+        panic!("MULTI_DRAW_INDIRECT feature must be enabled to call multi_draw_indirect")
+    }
+    fn multi_draw_indexed_indirect(
+        &mut self,
+        _indirect_buffer: &Sendable<web_sys::GpuBuffer>,
+        _indirect_offset: wgt::BufferAddress,
+        _count: u32,
+    ) {
+        panic!("MULTI_DRAW_INDIRECT feature must be enabled to call multi_draw_indexed_indirect")
+    }
+    fn multi_draw_indirect_count(
+        &mut self,
+        _indirect_buffer: &Sendable<web_sys::GpuBuffer>,
+        _indirect_offset: wgt::BufferAddress,
+        _count_buffer: &Sendable<web_sys::GpuBuffer>,
+        _count_buffer_offset: wgt::BufferAddress,
+        _max_count: u32,
+    ) {
+        panic!(
+            "MULTI_DRAW_INDIRECT_COUNT feature must be enabled to call multi_draw_indirect_count"
+        )
+    }
+    fn multi_draw_indexed_indirect_count(
+        &mut self,
+        _indirect_buffer: &Sendable<web_sys::GpuBuffer>,
+        _indirect_offset: wgt::BufferAddress,
+        _count_buffer: &Sendable<web_sys::GpuBuffer>,
+        _count_buffer_offset: wgt::BufferAddress,
+        _max_count: u32,
+    ) {
+        panic!("MULTI_DRAW_INDIRECT_COUNT feature must be enabled to call multi_draw_indexed_indirect_count")
+    }
 }
 
 impl crate::RenderPassInner<Context> for RenderPass {


### PR DESCRIPTION
The wgpu-rs component of https://github.com/gfx-rs/wgpu/pull/754.

I didn't include the modifications to the example as they are particularly awful and ugly. One of my next steps following this is to make an example of both binding indexing and these multi-draw extensions.