### PR TITLE
Split render pass docs into multiple sections, divided by feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1846,10 +1846,18 @@ impl<'a> RenderPass<'a> {
             .draw_indexed_indirect(&indirect_buffer.id, indirect_offset);
     }
 
+    /// Execute a [render bundle][RenderBundle], which is a set of pre-recorded commands
+    /// that can be run together.
+    pub fn execute_bundles<I: Iterator<Item = &'a RenderBundle>>(&mut self, render_bundles: I) {
+        self.id
+            .execute_bundles(render_bundles.into_iter().map(|rb| &rb.id))
+    }
+}
+
+/// [`Features::MULTI_DRAW_INDIRECT`] must be enabled on the device in order to call these functions.
+impl<'a> RenderPass<'a> {
     /// Disptaches multiple draw calls from the active vertex buffer(s) based on the contents of the `indirect_buffer`.
     /// `count` draw calls are issued.
-    ///
-    /// [`Features::MULTI_DRAW_INDIRECT`] must be enabled on the device in order to call this function.
     ///
     /// The active vertex buffers can be set with [`RenderPass::set_vertex_buffer`].
     ///
@@ -1879,8 +1887,6 @@ impl<'a> RenderPass<'a> {
     /// Disptaches multiple draw calls from the active index buffer and the active vertex buffers,
     /// based on the contents of the `indirect_buffer`. `count` draw calls are issued.
     ///
-    /// [`Features::MULTI_DRAW_INDIRECT`] must be enabled on the device in order to call this function.
-    ///
     /// The active index buffer can be set with [`RenderPass::set_index_buffer`], while the active
     /// vertex buffers can be set with [`RenderPass::set_vertex_buffer`].
     ///
@@ -1907,14 +1913,15 @@ impl<'a> RenderPass<'a> {
         self.id
             .multi_draw_indexed_indirect(&indirect_buffer.id, indirect_offset, count);
     }
+}
 
+/// [`Features::MULTI_DRAW_INDIRECT_COUNT`] must be enabled on the device in order to call these functions.
+impl<'a> RenderPass<'a> {
     /// Disptaches multiple draw calls from the active vertex buffer(s) based on the contents of the `indirect_buffer`.
     /// The count buffer is read to determine how many draws to issue.
     ///
     /// The indirect buffer must be long enough to account for `max_count` draws, however only `count` will
     /// draws will be read. If `count` is greater than `max_count`, `max_count` will be used.
-    ///
-    /// [`Features::MULTI_DRAW_INDIRECT_COUNT`] must be enabled on the device in order to call this function.
     ///
     /// The active vertex buffers can be set with [`RenderPass::set_vertex_buffer`].
     ///
@@ -1963,8 +1970,6 @@ impl<'a> RenderPass<'a> {
     /// The indirect buffer must be long enough to account for `max_count` draws, however only `count` will
     /// draws will be read. If `count` is greater than `max_count`, `max_count` will be used.
     ///
-    /// [`Features::MULTI_DRAW_INDIRECT_COUNT`] must be enabled on the device in order to call this function.
-    ///
     /// The active index buffer can be set with [`RenderPass::set_index_buffer`], while the active
     /// vertex buffers can be set with [`RenderPass::set_vertex_buffer`].
     ///
@@ -2006,13 +2011,6 @@ impl<'a> RenderPass<'a> {
             count_offset,
             max_count,
         );
-    }
-
-    /// Execute a [render bundle][RenderBundle], which is a set of pre-recorded commands
-    /// that can be run together.
-    pub fn execute_bundles<I: Iterator<Item = &'a RenderBundle>>(&mut self, render_bundles: I) {
-        self.id
-            .execute_bundles(render_bundles.into_iter().map(|rb| &rb.id))
     }
 }
 


### PR DESCRIPTION
This does not affect usage at all.

Here's what the docs look like:

<img width="1012" alt="Screen Shot 2020-07-09 at 11 11 30 AM" src="https://user-images.githubusercontent.com/31360811/87057532-fd974c00-c1d4-11ea-8c7f-913a893bcdef.png">
