### PR TITLE
[0.5] Add debug markers to command encoder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu"
-version = "0.5.1"
+version = "0.5.2"
 authors = [
     "Dzmitry Malyshau <kvark@mozilla.com>",
     "Joshua Groves <josh@joshgroves.com>",
@@ -25,7 +25,7 @@ vulkan = ["wgn/vulkan-portability"]
 
 [dependencies.wgn]
 package = "wgpu-native"
-version = "0.5"
+version = "0.5.1"
 #git = "https://github.com/gfx-rs/wgpu"
 
 [dependencies.wgc]
@@ -60,7 +60,7 @@ name="hello-compute"
 path="examples/hello-compute/main.rs"
 test = true
 
-#[patch.crates-io]
+[patch.crates-io]
 #wgpu-types = { version = "0.5.0", path = "../wgpu/wgpu-types" }
 #wgpu-core = { version = "0.5.0", path = "../wgpu/wgpu-core" }
 #wgpu-native = { version = "0.5.0", path = "../wgpu/wgpu-native" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1337,6 +1337,37 @@ impl CommandEncoder {
             copy_size,
         );
     }
+
+    /// Inserts debug marker.
+    pub fn insert_debug_marker(&mut self, label: &str) {
+        let cstring = CString::new(label).unwrap();
+        unsafe {
+            wgn::wgpu_command_encoder_insert_debug_marker(
+                self.id,
+                cstring.as_ptr(),
+                0,
+            )
+        };
+    }
+
+    /// Start record commands and group it into debug marker group.
+    pub fn push_debug_group(&mut self, label: &str) {
+        let cstring = CString::new(label).unwrap();
+        unsafe {
+            wgn::wgpu_command_encoder_push_debug_group(
+                self.id,
+                cstring.as_ptr(),
+                0,
+            )
+        };
+    }
+
+    /// Stops command recording and creates debug group.
+    pub fn pop_debug_group(&mut self) {
+        unsafe {
+            wgn::wgpu_command_encoder_pop_debug_group(self.id)
+        };
+    }
 }
 
 impl<'a> RenderPass<'a> {
@@ -1487,10 +1518,11 @@ impl<'a> RenderPass<'a> {
 
     /// Inserts debug marker.
     pub fn insert_debug_marker(&mut self, label: &str) {
+        let cstring = CString::new(label).unwrap();
         unsafe {
             wgn::wgpu_render_pass_insert_debug_marker(
                 self.id.as_mut().unwrap(),
-                label.as_ptr() as *const i8,
+                cstring.as_ptr(),
                 0,
             );
         }
@@ -1498,10 +1530,11 @@ impl<'a> RenderPass<'a> {
 
     /// Start record commands and group it into debug marker group.
     pub fn push_debug_group(&mut self, label: &str) {
+        let cstring = CString::new(label).unwrap();
         unsafe {
             wgn::wgpu_render_pass_push_debug_group(
                 self.id.as_mut().unwrap(),
-                label.as_ptr() as *const i8,
+                cstring.as_ptr(),
                 0,
             );
         }
@@ -1600,6 +1633,37 @@ impl<'a> ComputePass<'a> {
                 self.id.as_mut().unwrap(),
                 pipeline.id,
             );
+        }
+    }
+
+    /// Inserts debug marker.
+    pub fn insert_debug_marker(&mut self, label: &str) {
+        let cstring = CString::new(label).unwrap();
+        unsafe {
+            wgn::wgpu_compute_pass_insert_debug_marker(
+                self.id.as_mut().unwrap(),
+                cstring.as_ptr(),
+                0,
+            );
+        }
+    }
+
+    /// Start record commands and group it into debug marker group.
+    pub fn push_debug_group(&mut self, label: &str) {
+        let cstring = CString::new(label).unwrap();
+        unsafe {
+            wgn::wgpu_compute_pass_push_debug_group(
+                self.id.as_mut().unwrap(),
+                cstring.as_ptr(),
+                0,
+            );
+        }
+    }
+
+    /// Stops command recording and creates debug group.
+    pub fn pop_debug_group(&mut self) {
+        unsafe {
+            wgn::wgpu_compute_pass_pop_debug_group(self.id.as_mut().unwrap());
         }
     }
 


### PR DESCRIPTION
Follow-up to #427 
It fixes the safety/correctness of the markers, since there was a cast from `&str` to a null-terminated C string without a proper conversion.
Closes #431
Depends on https://github.com/gfx-rs/wgpu/pull/775