### PR TITLE
recreate swapchain on framework.rs examples on resize, ref #352

### DIFF
--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -237,6 +237,7 @@ fn start<E: Example>(
                 sc_desc.width = size.width;
                 sc_desc.height = size.height;
                 example.resize(&sc_desc, &device, &queue);
+                swap_chain = device.create_swap_chain(&surface, &sc_desc);
             }
             event::Event::WindowEvent { event, .. } => match event {
                 WindowEvent::KeyboardInput {


### PR DESCRIPTION
There still seem to be residual race condition like errors w.r.t. resizing on at least x11, but this does fix the panic on x11.