### PR TITLE
Remove Lifetimes from Push Constants

### DIFF
--- a/examples/texture-arrays/main.rs
+++ b/examples/texture-arrays/main.rs
@@ -335,27 +335,14 @@ impl framework::Example for Example {
             depth_stencil_attachment: None,
         });
 
-        let uniform_workaround_data = if self.uniform_workaround {
-            Some([Uniform { index: 0 }, Uniform { index: 1 }])
-        } else {
-            None
-        };
         rpass.set_pipeline(&self.pipeline);
         rpass.set_bind_group(0, &self.bind_group, &[]);
         rpass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
         rpass.set_index_buffer(self.index_buffer.slice(..));
-        if let Some(ref data) = uniform_workaround_data {
-            rpass.set_push_constants(
-                wgpu::ShaderStage::FRAGMENT,
-                0,
-                bytemuck::cast_slice(&data[0..1]),
-            );
+        if self.uniform_workaround {
+            rpass.set_push_constants(wgpu::ShaderStage::FRAGMENT, 0, bytemuck::cast_slice(&[0]));
             rpass.draw_indexed(0..6, 0, 0..1);
-            rpass.set_push_constants(
-                wgpu::ShaderStage::FRAGMENT,
-                0,
-                bytemuck::cast_slice(&data[1..2]),
-            );
+            rpass.set_push_constants(wgpu::ShaderStage::FRAGMENT, 0, bytemuck::cast_slice(&[1]));
             rpass.draw_indexed(6..12, 0, 0..1);
         } else {
             rpass.draw_indexed(0..12, 0, 0..1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1985,7 +1985,7 @@ impl<'a> RenderPass<'a> {
     ///
     /// You would need to upload this in three set_push_constants calls. First for the `Vertex` only range 0..4, second
     /// for the `Vertex | Fragment` range 4..8, third for the `Fragment` range 8..12.
-    pub fn set_push_constants(&mut self, stages: wgt::ShaderStage, offset: u32, data: &'a [u32]) {
+    pub fn set_push_constants(&mut self, stages: wgt::ShaderStage, offset: u32, data: &[u32]) {
         self.id.set_push_constants(stages, offset, data);
     }
 }
@@ -2045,7 +2045,7 @@ impl<'a> ComputePass<'a> {
     /// Data size must be a multiple of 4 and must be aligned to the 4s, so we take an array of u32.
     /// For example, with an offset of 4 and an array of `[u32; 3]`, that will write to the range
     /// of 4..16.
-    pub fn set_push_constants(&mut self, offset: u32, data: &'a [u32]) {
+    pub fn set_push_constants(&mut self, offset: u32, data: &[u32]) {
         self.id.set_push_constants(offset, data);
     }
 }
@@ -2214,7 +2214,7 @@ impl<'a> RenderBundleEncoder<'a> {
     ///
     /// You would need to upload this in three set_push_constants calls. First for the `Vertex` only range 0..4, second
     /// for the `Vertex | Fragment` range 4..8, third for the `Fragment` range 8..12.
-    pub fn set_push_constants(&mut self, stages: wgt::ShaderStage, offset: u32, data: &'a [u32]) {
+    pub fn set_push_constants(&mut self, stages: wgt::ShaderStage, offset: u32, data: &[u32]) {
         self.id.set_push_constants(stages, offset, data);
     }
 }


### PR DESCRIPTION
This is sound because for render passes, compute passes, and render bundles we immediately copy the data into an internal buffer then refer to the data by offset into the buffer.

This also cleans up the example a bit as we don't need the array to outlive the statement.