### PR TITLE
Implement more derives for `Operations`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ raw-window-handle = "0.3"
 smallvec = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 typed-arena = "2.0.1"
+serde = { version = "1", features = ["derive"], optional = true }
 
 #Note: we may consider switching this to "dev-dependencies" if users
 # want to opt into X11 explicitly.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ all-features = true
 
 [features]
 default = []
-trace = ["wgc/trace"]
-replay = ["wgc/replay"]
+trace = ["serde", "wgc/trace"]
+replay = ["serde", "wgc/replay"]
 subscriber = ["wgc/subscriber"]
 # Make Vulkan backend available on platforms where it is by default not, e.g. macOS
 vulkan = ["wgc/gfx-backend-vulkan"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -818,7 +818,7 @@ impl<V: Default> Default for LoadOp<V> {
 }
 
 /// Pair of load and store operations for an attachment aspect.
-#[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct Operations<V> {
@@ -826,6 +826,15 @@ pub struct Operations<V> {
     pub load: LoadOp<V>,
     /// Whether data will be written to through this attachment.
     pub store: bool,
+}
+
+impl<V: Default> Default for Operations<V> {
+    fn default() -> Self {
+        Self {
+            load: Default::default(),
+            store: true,
+        }
+    }
 }
 
 /// Describes a color attachment to a [`RenderPass`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,10 @@ use std::{
 
 use futures::FutureExt as _;
 use parking_lot::Mutex;
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "trace")]
+use serde::Serialize;
+#[cfg(feature = "replay")]
+use serde::Deserialize;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use wgc::instance::{AdapterInfo, DeviceType};
@@ -800,7 +802,8 @@ pub enum BindingResource<'a> {
 
 /// Operation to perform to the output attachment at the start of a renderpass.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "trace", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
 pub enum LoadOp<V> {
     /// Clear with a specified value.
     Clear(V),
@@ -816,7 +819,8 @@ impl<V: Default> Default for LoadOp<V> {
 
 /// Pair of load and store operations for an attachment aspect.
 #[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "trace", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct Operations<V> {
     /// How data should be read through this attachment.
     pub load: LoadOp<V>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ use std::{
 
 use futures::FutureExt as _;
 use parking_lot::Mutex;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use wgc::instance::{AdapterInfo, DeviceType};
@@ -797,7 +799,8 @@ pub enum BindingResource<'a> {
 }
 
 /// Operation to perform to the output attachment at the start of a renderpass.
-#[derive(Clone, Copy, Debug, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum LoadOp<V> {
     /// Clear with a specified value.
     Clear(V),
@@ -805,8 +808,15 @@ pub enum LoadOp<V> {
     Load,
 }
 
+impl<V: Default> Default for LoadOp<V> {
+    fn default() -> Self {
+        Self::Clear(Default::default())
+    }
+}
+
 /// Pair of load and store operations for an attachment aspect.
-#[derive(Clone, Debug, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Operations<V> {
     /// How data should be read through this attachment.
     pub load: LoadOp<V>,


### PR DESCRIPTION
- Implements a `Default` value for `LoadOp` and `Operations` when `V: Default`
- Derives `Eq` for those same traits
- Adds a new optional dependency `serde` which will derive the serialization traits for `LoadOp` and `Operations`, as requested in the issue

Closes #422