### PR TITLE
Added Static Lifetime to Statically Loaded SPIR-V Modules

### DIFF
--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -550,8 +550,8 @@ impl crate::Context for Context {
         source: ShaderModuleSource,
     ) -> Self::ShaderModuleId {
         let desc = match source {
-            ShaderModuleSource::SpirV(spv) => wgc::pipeline::ShaderModuleSource::SpirV(spv),
-            ShaderModuleSource::Wgsl(code) => wgc::pipeline::ShaderModuleSource::Wgsl(code),
+            ShaderModuleSource::SpirV(ref spv) => wgc::pipeline::ShaderModuleSource::SpirV(spv),
+            ShaderModuleSource::Wgsl(ref code) => wgc::pipeline::ShaderModuleSource::Wgsl(code),
         };
         gfx_select!(*device => self.device_create_shader_module(*device, desc, PhantomData))
     }

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -815,7 +815,7 @@ impl crate::Context for Context {
     ) -> Self::ShaderModuleId {
         let desc = match source {
             ShaderModuleSource::SpirV(spv) => {
-                web_sys::GpuShaderModuleDescriptor::new(&js_sys::Uint32Array::from(spv))
+                web_sys::GpuShaderModuleDescriptor::new(&js_sys::Uint32Array::from(&*spv))
             }
             ShaderModuleSource::Wgsl(_code) => {
                 panic!("WGSL is not yet supported by the Web backend")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod util;
 mod macros;
 
 use std::{
+    borrow::Cow,
     error::Error,
     fmt::{Debug, Display},
     future::Future,
@@ -620,14 +621,14 @@ pub enum ShaderModuleSource<'a> {
     ///
     /// wgpu will attempt to parse and validate it, but the original binary
     /// is passed to `gfx-rs` and `spirv_cross` for translation.
-    SpirV(&'a [u32]),
+    SpirV(Cow<'a, [u32]>),
     /// WGSL module as a string slice.
     ///
     /// wgpu-rs will parse it and use for validation. It will attempt
     /// to build a SPIR-V module internally and panic otherwise.
     ///
     /// Note: WGSL is not yet supported on the Web.
-    Wgsl(&'a str),
+    Wgsl(Cow<'a, str>),
 }
 
 /// Handle to a pipeline layout.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -144,6 +144,6 @@ fn test_vertex_attr_array() {
 #[macro_export]
 macro_rules! include_spirv {
     ($($token:tt)*) => {
-        $crate::util::make_spirv(&$crate::util::WordAligned(*include_bytes!($($token)*)).0)
+        $crate::util::make_spirv(include_bytes!($($token)*))
     };
 }


### PR DESCRIPTION
The commit enables `include_spirv!` to return a `ShaderModuleSource<'static>`.
This allows `ShaderModuleSource` to outlive the context in which `include_spirv!` was called in.
An example where this implementation would work but the previews would not is the following.
```rust
fn get_vertex_module<'a>() -> wgpu::ShaderModuleSource<'a> {
    wgpu::include_spirv!("shader.vert.spv")
}
let vs_module = device.create_shader_module(get_vertex_module());
```
Also it makes logical sense for a statically loaded module to have a static lifetime.  

The only downside that this change might bring is the redundant presence of the binary string (the non aligned binary string and the aligned binary string) but from the produced assembly I could only find one copy of the binary string so I don't think this is the case.