### PR TITLE
add debug trait for public types

### DIFF
--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -9,26 +9,16 @@ use crate::{
 use arrayvec::ArrayVec;
 use futures::future::{ready, Ready};
 use smallvec::SmallVec;
-use std::{ffi::CString, marker::PhantomData, ops::Range, ptr, slice};
+use std::{ffi::CString, fmt, marker::PhantomData, ops::Range, ptr, slice};
 use typed_arena::Arena;
 
-macro_rules! gfx_select {
-    ($id:expr => $global:ident.$method:ident( $($param:expr),+ )) => {
-        match $id.backend() {
-            #[cfg(any(not(any(target_os = "ios", target_os = "macos")), feature = "vulkan-portability"))]
-            wgt::Backend::Vulkan => $global.$method::<wgc::backend::Vulkan>( $($param),+ ),
-            #[cfg(any(target_os = "ios", target_os = "macos"))]
-            wgt::Backend::Metal => $global.$method::<wgc::backend::Metal>( $($param),+ ),
-            #[cfg(windows)]
-            wgt::Backend::Dx12 => $global.$method::<wgc::backend::Dx12>( $($param),+ ),
-            #[cfg(windows)]
-            wgt::Backend::Dx11 => $global.$method::<wgc::backend::Dx11>( $($param),+ ),
-            _ => unreachable!()
-        }
-    };
-}
+pub struct Context(pub wgc::hub::Global<wgc::hub::IdentityManagerFactory>);
 
-pub type Context = wgc::hub::Global<wgc::hub::IdentityManagerFactory>;
+impl fmt::Debug for Context {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Context").field("type", &"Native").finish()
+    }
+}
 
 mod pass_impl {
     use super::Context;
@@ -485,21 +475,25 @@ impl crate::Context for Context {
     type MapAsyncFuture = native_gpu_future::GpuFuture<Result<(), crate::BufferAsyncError>>;
 
     fn init(backends: wgt::BackendBit) -> Self {
-        wgc::hub::Global::new("wgpu", wgc::hub::IdentityManagerFactory, backends)
+        Self(wgc::hub::Global::new(
+            "wgpu",
+            wgc::hub::IdentityManagerFactory,
+            backends,
+        ))
     }
 
     fn instance_create_surface(
         &self,
         handle: &impl raw_window_handle::HasRawWindowHandle,
     ) -> Self::SurfaceId {
-        self.instance_create_surface(handle, PhantomData)
+        self.0.instance_create_surface(handle, PhantomData)
     }
 
     fn instance_request_adapter(
         &self,
         options: &crate::RequestAdapterOptions,
     ) -> Self::RequestAdapterFuture {
-        let id = self.pick_adapter(
+        let id = self.0.pick_adapter(
             &wgc::instance::RequestAdapterOptions {
                 power_preference: options.power_preference,
                 compatible_surface: options.compatible_surface.map(|surface| surface.id),
@@ -515,24 +509,29 @@ impl crate::Context for Context {
         desc: &crate::DeviceDescriptor,
         trace_dir: Option<&std::path::Path>,
     ) -> Self::RequestDeviceFuture {
-        let device_id = gfx_select!(*adapter => self.adapter_request_device(*adapter, desc, trace_dir, PhantomData)).unwrap();
+        let global = &self.0;
+        let device_id = wgc::gfx_select!(*adapter => global.adapter_request_device(*adapter, desc, trace_dir, PhantomData)).unwrap();
         ready(Ok((device_id, device_id)))
     }
 
     fn adapter_features(&self, adapter: &Self::AdapterId) -> Features {
-        gfx_select!(*adapter => self.adapter_features(*adapter))
+        let global = &self.0;
+        wgc::gfx_select!(*adapter => global.adapter_features(*adapter))
     }
 
     fn adapter_limits(&self, adapter: &Self::AdapterId) -> Limits {
-        gfx_select!(*adapter => self.adapter_limits(*adapter))
+        let global = &self.0;
+        wgc::gfx_select!(*adapter => global.adapter_limits(*adapter))
     }
 
     fn device_features(&self, device: &Self::DeviceId) -> Features {
-        gfx_select!(*device => self.device_features(*device))
+        let global = &self.0;
+        wgc::gfx_select!(*device => global.device_features(*device))
     }
 
     fn device_limits(&self, device: &Self::DeviceId) -> Limits {
-        gfx_select!(*device => self.device_limits(*device))
+        let global = &self.0;
+        wgc::gfx_select!(*device => global.device_limits(*device))
     }
 
     fn device_create_swap_chain(
@@ -541,7 +540,8 @@ impl crate::Context for Context {
         surface: &Self::SurfaceId,
         desc: &wgt::SwapChainDescriptor,
     ) -> Self::SwapChainId {
-        gfx_select!(*device => self.device_create_swap_chain(*device, *surface, desc))
+        let global = &self.0;
+        wgc::gfx_select!(*device => global.device_create_swap_chain(*device, *surface, desc))
     }
 
     fn device_create_shader_module(
@@ -553,7 +553,8 @@ impl crate::Context for Context {
             ShaderModuleSource::SpirV(ref spv) => wgc::pipeline::ShaderModuleSource::SpirV(spv),
             ShaderModuleSource::Wgsl(ref code) => wgc::pipeline::ShaderModuleSource::Wgsl(code),
         };
-        gfx_select!(*device => self.device_create_shader_module(*device, desc, PhantomData))
+        let global = &self.0;
+        wgc::gfx_select!(*device => global.device_create_shader_module(*device, desc, PhantomData))
     }
 
     fn device_create_bind_group_layout(
@@ -561,7 +562,8 @@ impl crate::Context for Context {
         device: &Self::DeviceId,
         desc: &BindGroupLayoutDescriptor,
     ) -> Self::BindGroupLayoutId {
-        gfx_select!(*device => self.device_create_bind_group_layout(
+        let global = &self.0;
+        wgc::gfx_select!(*device => global.device_create_bind_group_layout(
             *device,
             desc,
             PhantomData
@@ -607,7 +609,8 @@ impl crate::Context for Context {
             })
             .collect::<Vec<_>>();
 
-        gfx_select!(*device => self.device_create_bind_group(
+        let global = &self.0;
+        wgc::gfx_select!(*device => global.device_create_bind_group(
             *device,
             &bm::BindGroupDescriptor {
                 label: desc.label,
@@ -641,7 +644,8 @@ impl crate::Context for Context {
             .map(|bgl| bgl.id)
             .collect::<ArrayVec<[_; wgc::MAX_BIND_GROUPS]>>();
 
-        gfx_select!(*device => self.device_create_pipeline_layout(
+        let global = &self.0;
+        wgc::gfx_select!(*device => global.device_create_pipeline_layout(
             *device,
             &wgt::PipelineLayoutDescriptor {
                 bind_group_layouts: &temp_layouts,
@@ -672,7 +676,8 @@ impl crate::Context for Context {
                     entry_point: fs.entry_point,
                 });
 
-        gfx_select!(*device => self.device_create_render_pipeline(
+        let global = &self.0;
+        wgc::gfx_select!(*device => global.device_create_render_pipeline(
             *device,
             &pipe::RenderPipelineDescriptor {
                 layout: desc.layout.id,
@@ -699,7 +704,8 @@ impl crate::Context for Context {
     ) -> Self::ComputePipelineId {
         use wgc::pipeline as pipe;
 
-        gfx_select!(*device => self.device_create_compute_pipeline(
+        let global = &self.0;
+        wgc::gfx_select!(*device => global.device_create_compute_pipeline(
             *device,
             &pipe::ComputePipelineDescriptor {
                 layout: desc.layout.id,
@@ -719,7 +725,9 @@ impl crate::Context for Context {
         desc: &BufferDescriptor,
     ) -> Self::BufferId {
         let owned_label = OwnedLabel::new(desc.label.as_deref());
-        gfx_select!(*device => self.device_create_buffer(
+
+        let global = &self.0;
+        wgc::gfx_select!(*device => global.device_create_buffer(
             *device,
             &desc.map_label(|_| owned_label.as_ptr()),
             PhantomData
@@ -733,7 +741,9 @@ impl crate::Context for Context {
         desc: &TextureDescriptor,
     ) -> Self::TextureId {
         let owned_label = OwnedLabel::new(desc.label.as_deref());
-        gfx_select!(*device => self.device_create_texture(
+
+        let global = &self.0;
+        wgc::gfx_select!(*device => global.device_create_texture(
             *device,
             &desc.map_label(|_| owned_label.as_ptr()),
             PhantomData
@@ -747,7 +757,9 @@ impl crate::Context for Context {
         desc: &SamplerDescriptor,
     ) -> Self::SamplerId {
         let owned_label = OwnedLabel::new(desc.label.as_deref());
-        gfx_select!(*device => self.device_create_sampler(
+
+        let global = &self.0;
+        wgc::gfx_select!(*device => global.device_create_sampler(
             *device,
             &desc.map_label(|_| owned_label.as_ptr()),
             PhantomData
@@ -760,7 +772,9 @@ impl crate::Context for Context {
         desc: &CommandEncoderDescriptor,
     ) -> Self::CommandEncoderId {
         let owned_label = OwnedLabel::new(desc.label.as_deref());
-        gfx_select!(*device => self.device_create_command_encoder(
+
+        let global = &self.0;
+        wgc::gfx_select!(*device => global.device_create_command_encoder(
             *device,
             &wgt::CommandEncoderDescriptor {
                 label: owned_label.as_ptr(),
@@ -779,15 +793,22 @@ impl crate::Context for Context {
 
     fn device_drop(&self, device: &Self::DeviceId) {
         #[cfg(not(target_arch = "wasm32"))]
-        gfx_select!(*device => self.device_poll(*device, true)).unwrap();
+        {
+            let global = &self.0;
+            wgc::gfx_select!(*device => global.device_poll(*device, true)).unwrap();
+        }
         //TODO: make this work in general
         #[cfg(not(target_arch = "wasm32"))]
         #[cfg(feature = "metal-auto-capture")]
-        gfx_select!(*device => self.device_destroy(*device));
+        {
+            let global = &self.0;
+            wgc::gfx_select!(*device => global.device_destroy(*device));
+        }
     }
 
     fn device_poll(&self, device: &Self::DeviceId, maintain: crate::Maintain) {
-        gfx_select!(*device => self.device_poll(
+        let global = &self.0;
+        wgc::gfx_select!(*device => global.device_poll(
             *device,
             match maintain {
                 crate::Maintain::Poll => false,
@@ -827,7 +848,9 @@ impl crate::Context for Context {
             callback: buffer_map_future_wrapper,
             user_data: completion.to_raw() as _,
         };
-        gfx_select!(*buffer => self.buffer_map_async(*buffer, range, operation)).unwrap();
+
+        let global = &self.0;
+        wgc::gfx_select!(*buffer => global.buffer_map_async(*buffer, range, operation)).unwrap();
 
         future
     }
@@ -838,7 +861,8 @@ impl crate::Context for Context {
         sub_range: Range<wgt::BufferAddress>,
     ) -> &[u8] {
         let size = sub_range.end - sub_range.start;
-        let ptr = gfx_select!(*buffer => self.buffer_get_mapped_range(
+        let global = &self.0;
+        let ptr = wgc::gfx_select!(*buffer => global.buffer_get_mapped_range(
             *buffer,
             sub_range.start,
             wgt::BufferSize::new(size)
@@ -853,7 +877,8 @@ impl crate::Context for Context {
         sub_range: Range<wgt::BufferAddress>,
     ) -> &mut [u8] {
         let size = sub_range.end - sub_range.start;
-        let ptr = gfx_select!(*buffer => self.buffer_get_mapped_range(
+        let global = &self.0;
+        let ptr = wgc::gfx_select!(*buffer => global.buffer_get_mapped_range(
             *buffer,
             sub_range.start,
             wgt::BufferSize::new(size)
@@ -863,7 +888,8 @@ impl crate::Context for Context {
     }
 
     fn buffer_unmap(&self, buffer: &Self::BufferId) {
-        gfx_select!(*buffer => self.buffer_unmap(*buffer)).unwrap();
+        let global = &self.0;
+        wgc::gfx_select!(*buffer => global.buffer_unmap(*buffer)).unwrap();
     }
 
     fn swap_chain_get_current_texture_view(
@@ -874,8 +900,9 @@ impl crate::Context for Context {
         SwapChainStatus,
         Self::SwapChainOutputDetail,
     ) {
+        let global = &self.0;
         let wgc::swap_chain::SwapChainOutput { status, view_id } =
-            gfx_select!(*swap_chain => self.swap_chain_get_current_texture_view(*swap_chain, PhantomData)).unwrap();
+            wgc::gfx_select!(*swap_chain => global.swap_chain_get_current_texture_view(*swap_chain, PhantomData)).unwrap();
 
         (
             view_id,
@@ -887,7 +914,8 @@ impl crate::Context for Context {
     }
 
     fn swap_chain_present(&self, view: &Self::TextureViewId, detail: &Self::SwapChainOutputDetail) {
-        gfx_select!(*view => self.swap_chain_present(detail.swap_chain_id)).unwrap();
+        let global = &self.0;
+        wgc::gfx_select!(*view => global.swap_chain_present(detail.swap_chain_id)).unwrap();
     }
 
     fn texture_create_view(
@@ -897,44 +925,57 @@ impl crate::Context for Context {
     ) -> Self::TextureViewId {
         let owned_label = OwnedLabel::new(desc.and_then(|d| d.label.as_deref()));
         let descriptor = desc.map(|d| d.map_label(|_| owned_label.as_ptr()));
-        gfx_select!(*texture => self.texture_create_view(*texture, descriptor.as_ref(), PhantomData))
+        let global = &self.0;
+        wgc::gfx_select!(*texture => global.texture_create_view(*texture, descriptor.as_ref(), PhantomData))
     }
 
     fn texture_drop(&self, texture: &Self::TextureId) {
-        gfx_select!(*texture => self.texture_destroy(*texture))
+        let global = &self.0;
+        wgc::gfx_select!(*texture => global.texture_destroy(*texture))
     }
     fn texture_view_drop(&self, texture_view: &Self::TextureViewId) {
-        gfx_select!(*texture_view => self.texture_view_destroy(*texture_view))
+        let global = &self.0;
+        wgc::gfx_select!(*texture_view => global.texture_view_destroy(*texture_view))
     }
     fn sampler_drop(&self, sampler: &Self::SamplerId) {
-        gfx_select!(*sampler => self.sampler_destroy(*sampler))
+        let global = &self.0;
+        wgc::gfx_select!(*sampler => global.sampler_destroy(*sampler))
     }
     fn buffer_drop(&self, buffer: &Self::BufferId) {
-        gfx_select!(*buffer => self.buffer_destroy(*buffer))
+        let global = &self.0;
+        wgc::gfx_select!(*buffer => global.buffer_destroy(*buffer))
     }
     fn bind_group_drop(&self, bind_group: &Self::BindGroupId) {
-        gfx_select!(*bind_group => self.bind_group_destroy(*bind_group))
+        let global = &self.0;
+        wgc::gfx_select!(*bind_group => global.bind_group_destroy(*bind_group))
     }
     fn bind_group_layout_drop(&self, bind_group_layout: &Self::BindGroupLayoutId) {
-        gfx_select!(*bind_group_layout => self.bind_group_layout_destroy(*bind_group_layout))
+        let global = &self.0;
+        wgc::gfx_select!(*bind_group_layout => global.bind_group_layout_destroy(*bind_group_layout))
     }
     fn pipeline_layout_drop(&self, pipeline_layout: &Self::PipelineLayoutId) {
-        gfx_select!(*pipeline_layout => self.pipeline_layout_destroy(*pipeline_layout))
+        let global = &self.0;
+        wgc::gfx_select!(*pipeline_layout => global.pipeline_layout_destroy(*pipeline_layout))
     }
     fn shader_module_drop(&self, shader_module: &Self::ShaderModuleId) {
-        gfx_select!(*shader_module => self.shader_module_destroy(*shader_module))
+        let global = &self.0;
+        wgc::gfx_select!(*shader_module => global.shader_module_destroy(*shader_module))
     }
     fn command_buffer_drop(&self, command_buffer: &Self::CommandBufferId) {
-        gfx_select!(*command_buffer => self.command_buffer_destroy(*command_buffer))
+        let global = &self.0;
+        wgc::gfx_select!(*command_buffer => global.command_buffer_destroy(*command_buffer))
     }
     fn render_bundle_drop(&self, render_bundle: &Self::RenderBundleId) {
-        gfx_select!(*render_bundle => self.render_bundle_destroy(*render_bundle))
+        let global = &self.0;
+        wgc::gfx_select!(*render_bundle => global.render_bundle_destroy(*render_bundle))
     }
     fn compute_pipeline_drop(&self, pipeline: &Self::ComputePipelineId) {
-        gfx_select!(*pipeline => self.compute_pipeline_destroy(*pipeline))
+        let global = &self.0;
+        wgc::gfx_select!(*pipeline => global.compute_pipeline_destroy(*pipeline))
     }
     fn render_pipeline_drop(&self, pipeline: &Self::RenderPipelineId) {
-        gfx_select!(*pipeline => self.render_pipeline_destroy(*pipeline))
+        let global = &self.0;
+        wgc::gfx_select!(*pipeline => global.render_pipeline_destroy(*pipeline))
     }
 
     fn command_encoder_copy_buffer_to_buffer(
@@ -946,7 +987,8 @@ impl crate::Context for Context {
         destination_offset: wgt::BufferAddress,
         copy_size: wgt::BufferAddress,
     ) {
-        gfx_select!(*encoder => self.command_encoder_copy_buffer_to_buffer(
+        let global = &self.0;
+        wgc::gfx_select!(*encoder => global.command_encoder_copy_buffer_to_buffer(
             *encoder,
             *source,
             source_offset,
@@ -964,7 +1006,8 @@ impl crate::Context for Context {
         destination: crate::TextureCopyView,
         copy_size: wgt::Extent3d,
     ) {
-        gfx_select!(*encoder => self.command_encoder_copy_buffer_to_texture(
+        let global = &self.0;
+        wgc::gfx_select!(*encoder => global.command_encoder_copy_buffer_to_texture(
             *encoder,
             &map_buffer_copy_view(source),
             &map_texture_copy_view(destination),
@@ -980,7 +1023,8 @@ impl crate::Context for Context {
         destination: crate::BufferCopyView,
         copy_size: wgt::Extent3d,
     ) {
-        gfx_select!(*encoder => self.command_encoder_copy_texture_to_buffer(
+        let global = &self.0;
+        wgc::gfx_select!(*encoder => global.command_encoder_copy_texture_to_buffer(
             *encoder,
             &map_texture_copy_view(source),
             &map_buffer_copy_view(destination),
@@ -996,7 +1040,8 @@ impl crate::Context for Context {
         destination: crate::TextureCopyView,
         copy_size: wgt::Extent3d,
     ) {
-        gfx_select!(*encoder => self.command_encoder_copy_texture_to_texture(
+        let global = &self.0;
+        wgc::gfx_select!(*encoder => global.command_encoder_copy_texture_to_texture(
             *encoder,
             &map_texture_copy_view(source),
             &map_texture_copy_view(destination),
@@ -1017,7 +1062,9 @@ impl crate::Context for Context {
         encoder: &Self::CommandEncoderId,
         pass: &mut Self::ComputePassId,
     ) {
-        gfx_select!(*encoder => self.command_encoder_run_compute_pass(*encoder, pass)).unwrap()
+        let global = &self.0;
+        wgc::gfx_select!(*encoder => global.command_encoder_run_compute_pass(*encoder, pass))
+            .unwrap()
     }
 
     fn command_encoder_begin_render_pass<'a>(
@@ -1058,12 +1105,15 @@ impl crate::Context for Context {
         encoder: &Self::CommandEncoderId,
         pass: &mut Self::RenderPassId,
     ) {
-        gfx_select!(*encoder => self.command_encoder_run_render_pass(*encoder, pass)).unwrap()
+        let global = &self.0;
+        wgc::gfx_select!(*encoder => global.command_encoder_run_render_pass(*encoder, pass))
+            .unwrap()
     }
 
     fn command_encoder_finish(&self, encoder: &Self::CommandEncoderId) -> Self::CommandBufferId {
         let desc = wgt::CommandBufferDescriptor::default();
-        gfx_select!(*encoder => self.command_encoder_finish(*encoder, &desc)).unwrap()
+        let global = &self.0;
+        wgc::gfx_select!(*encoder => global.command_encoder_finish(*encoder, &desc)).unwrap()
     }
 
     fn render_bundle_encoder_finish(
@@ -1072,7 +1122,8 @@ impl crate::Context for Context {
         desc: &crate::RenderBundleDescriptor,
     ) -> Self::RenderBundleId {
         let owned_label = OwnedLabel::new(desc.label.as_deref());
-        gfx_select!(encoder.parent() => self.render_bundle_encoder_finish(
+        let global = &self.0;
+        wgc::gfx_select!(encoder.parent() => global.render_bundle_encoder_finish(
             encoder,
             &desc.map_label(|_| owned_label.as_ptr()),
             PhantomData
@@ -1087,7 +1138,8 @@ impl crate::Context for Context {
         offset: wgt::BufferAddress,
         data: &[u8],
     ) {
-        gfx_select!(*queue => self.queue_write_buffer(*queue, *buffer, offset, data))
+        let global = &self.0;
+        wgc::gfx_select!(*queue => global.queue_write_buffer(*queue, *buffer, offset, data))
     }
 
     fn queue_write_texture(
@@ -1098,7 +1150,8 @@ impl crate::Context for Context {
         data_layout: wgt::TextureDataLayout,
         size: wgt::Extent3d,
     ) {
-        gfx_select!(*queue => self.queue_write_texture(
+        let global = &self.0;
+        wgc::gfx_select!(*queue => global.queue_write_texture(
             *queue,
             &map_texture_copy_view(texture),
             data,
@@ -1114,7 +1167,8 @@ impl crate::Context for Context {
     ) {
         let temp_command_buffers = command_buffers.collect::<SmallVec<[_; 4]>>();
 
-        gfx_select!(*queue => self.queue_submit(*queue, &temp_command_buffers)).unwrap()
+        let global = &self.0;
+        wgc::gfx_select!(*queue => global.queue_submit(*queue, &temp_command_buffers)).unwrap()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,28 +146,28 @@ trait RenderPassInner<Ctx: Context>: RenderInner<Ctx> {
     );
 }
 
-trait Context: Sized {
-    type AdapterId: Send + Sync + 'static;
-    type DeviceId: Send + Sync + 'static;
-    type QueueId: Send + Sync + 'static;
-    type ShaderModuleId: Send + Sync + 'static;
-    type BindGroupLayoutId: Send + Sync + 'static;
-    type BindGroupId: Send + Sync + 'static;
-    type TextureViewId: Send + Sync + 'static;
-    type SamplerId: Send + Sync + 'static;
-    type BufferId: Send + Sync + 'static;
-    type TextureId: Send + Sync + 'static;
-    type PipelineLayoutId: Send + Sync + 'static;
-    type RenderPipelineId: Send + Sync + 'static;
-    type ComputePipelineId: Send + Sync + 'static;
-    type CommandEncoderId;
-    type ComputePassId: ComputePassInner<Self>;
-    type RenderPassId: RenderPassInner<Self>;
-    type CommandBufferId: Send + Sync;
+trait Context: Debug + Send + Sized + Sync {
+    type AdapterId: Debug + Send + Sync + 'static;
+    type DeviceId: Debug + Send + Sync + 'static;
+    type QueueId: Debug + Send + Sync + 'static;
+    type ShaderModuleId: Debug + Send + Sync + 'static;
+    type BindGroupLayoutId: Debug + Send + Sync + 'static;
+    type BindGroupId: Debug + Send + Sync + 'static;
+    type TextureViewId: Debug + Send + Sync + 'static;
+    type SamplerId: Debug + Send + Sync + 'static;
+    type BufferId: Debug + Send + Sync + 'static;
+    type TextureId: Debug + Send + Sync + 'static;
+    type PipelineLayoutId: Debug + Send + Sync + 'static;
+    type RenderPipelineId: Debug + Send + Sync + 'static;
+    type ComputePipelineId: Debug + Send + Sync + 'static;
+    type CommandEncoderId: Debug;
+    type ComputePassId: Debug + ComputePassInner<Self>;
+    type RenderPassId: Debug + RenderPassInner<Self>;
+    type CommandBufferId: Debug + Send + Sync;
     type RenderBundleEncoderId: RenderInner<Self>;
-    type RenderBundleId: Send + Sync + 'static;
-    type SurfaceId: Send + Sync + 'static;
-    type SwapChainId: Send + Sync + 'static;
+    type RenderBundleId: Debug + Send + Sync + 'static;
+    type SurfaceId: Debug + Send + Sync + 'static;
+    type SwapChainId: Debug + Send + Sync + 'static;
 
     type SwapChainOutputDetail: Send;
 
@@ -390,6 +390,7 @@ trait Context: Sized {
 /// Its primary use is to create [`Adapter`]s and [`Surface`]s.
 ///
 /// Does not have to be kept alive.
+#[derive(Debug)]
 pub struct Instance {
     context: Arc<C>,
 }
@@ -400,6 +401,7 @@ pub struct Instance {
 /// on the host system by using [`Adapter::request_device`].
 ///
 /// Does not have to be kept alive.
+#[derive(Debug)]
 pub struct Adapter {
     context: Arc<C>,
     id: <C as Context>::AdapterId,
@@ -411,6 +413,7 @@ pub struct Adapter {
 /// These are then used in commands, which are submitted to a [`Queue`].
 ///
 /// A device may be requested from an adapter with [`Adapter::request_device`].
+#[derive(Debug)]
 pub struct Device {
     context: Arc<C>,
     id: <C as Context>::DeviceId,
@@ -490,6 +493,7 @@ impl MapContext {
 /// Handle to a GPU-accessible buffer.
 ///
 /// Created with [`Device::create_buffer`] or [`Device::create_buffer_with_data`]
+#[derive(Debug)]
 pub struct Buffer {
     context: Arc<C>,
     id: <C as Context>::BufferId,
@@ -502,7 +506,7 @@ pub struct Buffer {
 /// Created by calling [`Buffer::slice`]. To use the whole buffer, call with unbounded slice:
 ///
 /// `buffer.slice(..)`
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct BufferSlice<'a> {
     buffer: &'a Buffer,
     offset: BufferAddress,
@@ -512,6 +516,7 @@ pub struct BufferSlice<'a> {
 /// Handle to a texture on the GPU.
 ///
 /// Created by calling [`Device::create_texture`]
+#[derive(Debug)]
 pub struct Texture {
     context: Arc<C>,
     id: <C as Context>::TextureId,
@@ -522,6 +527,7 @@ pub struct Texture {
 ///
 /// A `TextureView` object describes a texture and associated metadata needed by a
 /// [`RenderPipeline`] or [`BindGroup`].
+#[derive(Debug)]
 pub struct TextureView {
     context: Arc<C>,
     id: <C as Context>::TextureViewId,
@@ -533,6 +539,7 @@ pub struct TextureView {
 /// A `Sampler` object defines how a pipeline will sample from a [`TextureView`]. Samplers define
 /// image filters (including anisotropy) and address (wrapping) modes, among other things. See
 /// the documentation for [`SamplerDescriptor`] for more information.
+#[derive(Debug)]
 pub struct Sampler {
     context: Arc<C>,
     id: <C as Context>::SamplerId,
@@ -550,6 +557,7 @@ impl Drop for Sampler {
 ///
 /// A `Surface` represents a platform-specific surface (e.g. a window) onto which rendered images may
 /// be presented. A `Surface` may be created with the unsafe function [`Instance::create_surface`].
+#[derive(Debug)]
 pub struct Surface {
     id: <C as Context>::SurfaceId,
 }
@@ -558,6 +566,7 @@ pub struct Surface {
 ///
 /// A `SwapChain` represents the image or series of images that will be presented to a [`Surface`].
 /// A `SwapChain` may be created with [`Device::create_swap_chain`].
+#[derive(Debug)]
 pub struct SwapChain {
     context: Arc<C>,
     id: <C as Context>::SwapChainId,
@@ -569,6 +578,7 @@ pub struct SwapChain {
 /// create a [`BindGroupDescriptor`] object, which in turn can be used to create a [`BindGroup`]
 /// object with [`Device::create_bind_group`]. A series of `BindGroupLayout`s can also be used to
 /// create a [`PipelineLayoutDescriptor`], which can be used to create a [`PipelineLayout`].
+#[derive(Debug)]
 pub struct BindGroupLayout {
     context: Arc<C>,
     id: <C as Context>::BindGroupLayoutId,
@@ -588,6 +598,7 @@ impl Drop for BindGroupLayout {
 /// [`BindGroupLayout`]. It can be created with [`Device::create_bind_group`]. A `BindGroup` can
 /// be bound to a particular [`RenderPass`] with [`RenderPass::set_bind_group`], or to a
 /// [`ComputePass`] with [`ComputePass::set_bind_group`].
+#[derive(Debug)]
 pub struct BindGroup {
     context: Arc<C>,
     id: <C as Context>::BindGroupId,
@@ -606,6 +617,7 @@ impl Drop for BindGroup {
 /// A `ShaderModule` represents a compiled shader module on the GPU. It can be created by passing
 /// valid SPIR-V source code to [`Device::create_shader_module`]. Shader modules are used to define
 /// programmable stages of a pipeline.
+#[derive(Debug)]
 pub struct ShaderModule {
     context: Arc<C>,
     id: <C as Context>::ShaderModuleId,
@@ -638,6 +650,7 @@ pub enum ShaderModuleSource<'a> {
 /// Handle to a pipeline layout.
 ///
 /// A `PipelineLayout` object describes the available binding groups of a pipeline.
+#[derive(Debug)]
 pub struct PipelineLayout {
     context: Arc<C>,
     id: <C as Context>::PipelineLayoutId,
@@ -655,6 +668,7 @@ impl Drop for PipelineLayout {
 ///
 /// A `RenderPipeline` object represents a graphics pipeline and its stages, bindings, vertex
 /// buffers and targets. A `RenderPipeline` may be created with [`Device::create_render_pipeline`].
+#[derive(Debug)]
 pub struct RenderPipeline {
     context: Arc<C>,
     id: <C as Context>::RenderPipelineId,
@@ -672,6 +686,7 @@ impl Drop for RenderPipeline {
 ///
 /// A `ComputePipeline` object represents a compute pipeline and its single shader stage.
 /// A `ComputePipeline` may be created with [`Device::create_compute_pipeline`].
+#[derive(Debug)]
 pub struct ComputePipeline {
     context: Arc<C>,
     id: <C as Context>::ComputePipelineId,
@@ -690,6 +705,7 @@ impl Drop for ComputePipeline {
 /// A `CommandBuffer` represents a complete sequence of commands that may be submitted to a command
 /// queue with [`Queue::submit`]. A `CommandBuffer` is obtained by recording a series of commands to
 /// a [`CommandEncoder`] and then calling [`CommandEncoder::finish`].
+#[derive(Debug)]
 pub struct CommandBuffer {
     context: Arc<C>,
     id: Option<<C as Context>::CommandBufferId>,
@@ -712,6 +728,7 @@ impl Drop for CommandBuffer {
 ///
 /// When finished recording, call [`CommandEncoder::finish`] to obtain a [`CommandBuffer`] which may
 /// be submitted for execution.
+#[derive(Debug)]
 pub struct CommandEncoder {
     context: Arc<C>,
     id: <C as Context>::CommandEncoderId,
@@ -721,12 +738,14 @@ pub struct CommandEncoder {
 }
 
 /// In-progress recording of a render pass.
+#[derive(Debug)]
 pub struct RenderPass<'a> {
     id: <C as Context>::RenderPassId,
     parent: &'a mut CommandEncoder,
 }
 
 /// In-progress recording of a compute pass.
+#[derive(Debug)]
 pub struct ComputePass<'a> {
     id: <C as Context>::ComputePassId,
     parent: &'a mut CommandEncoder,
@@ -753,6 +772,7 @@ pub struct RenderBundleEncoder<'a> {
 /// can be executed onto a [`CommandEncoder`] using [`RenderPass::execute_bundles`].
 ///
 /// Executing a [`RenderBundle`] is often more efficient then issuing the underlying commands manually.
+#[derive(Debug)]
 pub struct RenderBundle {
     context: Arc<C>,
     id: <C as Context>::RenderBundleId,
@@ -770,6 +790,7 @@ impl Drop for RenderBundle {
 ///
 /// A `Queue` executes recorded [`CommandBuffer`] objects and provides convenience methods
 /// for writing to [buffers](Queue::write_buffer) and [textures](Queue::write_texture).
+#[derive(Debug)]
 pub struct Queue {
     context: Arc<C>,
     id: <C as Context>::QueueId,
@@ -839,7 +860,7 @@ impl<V: Default> Default for Operations<V> {
 }
 
 /// Describes a color attachment to a [`RenderPass`].
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RenderPassColorAttachmentDescriptor<'a> {
     /// The view to use as an attachment.
     pub attachment: &'a TextureView,
@@ -850,7 +871,7 @@ pub struct RenderPassColorAttachmentDescriptor<'a> {
 }
 
 /// Describes a depth/stencil attachment to a [`RenderPass`].
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RenderPassDepthStencilAttachmentDescriptor<'a> {
     /// The view to use as an attachment.
     pub attachment: &'a TextureView,
@@ -934,6 +955,7 @@ pub use wgt::TextureCopyView as TextureCopyViewBase;
 pub type TextureCopyView<'a> = TextureCopyViewBase<&'a Texture>;
 
 /// Swap chain image that can be rendered to.
+#[derive(Debug)]
 pub struct SwapChainTexture {
     /// Accessible view of the frame.
     pub view: TextureView,
@@ -941,6 +963,7 @@ pub struct SwapChainTexture {
 }
 
 /// Result of a successful call to [`SwapChain::get_next_frame`].
+#[derive(Debug)]
 pub struct SwapChainFrame {
     /// The texture into which the next frame should be rendered.
     pub output: SwapChainTexture,
@@ -997,6 +1020,7 @@ impl Instance {
     pub fn enumerate_adapters(&self, backends: BackendBit) -> impl Iterator<Item = Adapter> {
         let context = Arc::clone(&self.context);
         self.context
+            .0
             .enumerate_adapters(wgc::instance::AdapterInputs::Mask(backends, |_| {
                 PhantomData
             }))
@@ -1049,13 +1073,13 @@ impl Instance {
         let surface = wgc::instance::Surface {
             #[cfg(feature = "vulkan-portability")]
             vulkan: None, //TODO: create_surface_from_layer ?
-            metal: self.context.instance.metal.as_ref().map(|inst| {
+            metal: self.context.0.instance.metal.as_ref().map(|inst| {
                 inst.create_surface_from_layer(layer as *mut _, cfg!(debug_assertions))
             }),
         };
 
         crate::Surface {
-            id: self.context.surfaces.register_identity(
+            id: self.context.0.surfaces.register_identity(
                 PhantomData,
                 surface,
                 &mut wgc::hub::Token::root(),
@@ -1122,8 +1146,8 @@ impl Adapter {
     /// Get info about the adapter itself.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn get_info(&self) -> AdapterInfo {
-        let context = &self.context;
-        wgc::gfx_select!(self.id => context.adapter_get_info(self.id))
+        let global = &self.context.0;
+        wgc::gfx_select!(self.id => global.adapter_get_info(self.id))
     }
 }
 
@@ -1248,7 +1272,8 @@ impl Device {
             mapped_at_creation: true,
         });
 
-        let range = Context::buffer_get_mapped_range_mut(&*self.context, &buffer.id, 0..padded_size);
+        let range =
+            Context::buffer_get_mapped_range_mut(&*self.context, &buffer.id, 0..padded_size);
         range[0..unpadded_size as usize].copy_from_slice(&data);
         for i in unpadded_size..padded_size {
             range[i as usize] = 0;
@@ -1352,12 +1377,14 @@ fn range_to_offset_size<S: RangeBounds<BufferAddress>>(
 }
 
 /// Read only view into a mapped buffer.
+#[derive(Debug)]
 pub struct BufferView<'a> {
     slice: BufferSlice<'a>,
     data: &'a [u8],
 }
 
 /// Write only view into mapped buffer.
+#[derive(Debug)]
 pub struct BufferViewMut<'a> {
     slice: BufferSlice<'a>,
     data: &'a mut [u8],


### PR DESCRIPTION
This pull request is to resolve the issue #458.
This pull request is still incomplete. The only problematic trait is `RenderBundleEncoder`.
For the native version, `RenderBundleEncoder` does not implement `Debug`. This would have to be implemented in the wgpu project.
 FYI, Context does not need to implement `Debug`. The type that implements `Context` is used directly, i.e. `Arc<C>` is used and not `Arc<dyn Context>`
