### PR TITLE
Change deployment target to wgpu-rs.github.io

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
           FOLDER: target/doc
+          REPOSITORY_NAME: gfx-rs/wgpu-rs.github.io
+          BRANCH: master
           TARGET_FOLDER: doc 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
           FOLDER: target/generated
+          REPOSITORY_NAME: gfx-rs/wgpu-rs.github.io
+          BRANCH: master
           TARGET_FOLDER: examples


### PR DESCRIPTION
Using "gh-pages" branch for the website is not idiomatic to Git. This PR changes the deployment to https://github.com/gfx-rs/wgpu-rs.github.io instead