### PR TITLE
Split framework limit situation into requested/required

### DIFF
--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -203,7 +203,7 @@ impl Example {
 }
 
 impl framework::Example for Example {
-    fn needed_features() -> wgpu::Features {
+    fn optional_features() -> wgpu::Features {
         wgpu::Features::DEPTH_CLAMPING
     }
 

--- a/examples/texture-arrays/main.rs
+++ b/examples/texture-arrays/main.rs
@@ -80,14 +80,16 @@ struct Example {
 }
 
 impl framework::Example for Example {
-    fn needed_features() -> wgpu::Features {
+    fn optional_features() -> wgpu::Features {
         wgpu::Features::UNSIZED_BINDING_ARRAY
             | wgpu::Features::SAMPLED_TEXTURE_ARRAY_NON_UNIFORM_INDEXING
             | wgpu::Features::SAMPLED_TEXTURE_ARRAY_DYNAMIC_INDEXING
-            | wgpu::Features::SAMPLED_TEXTURE_BINDING_ARRAY
             | wgpu::Features::PUSH_CONSTANTS
     }
-    fn needed_limits() -> wgpu::Limits {
+    fn required_features() -> wgpu::Features {
+        wgpu::Features::SAMPLED_TEXTURE_BINDING_ARRAY
+    }
+    fn required_limits() -> wgpu::Limits {
         wgpu::Limits {
             max_push_constant_size: 4,
             ..wgpu::Limits::default()
@@ -114,11 +116,7 @@ impl framework::Example for Example {
             f if f.contains(wgpu::Features::SAMPLED_TEXTURE_BINDING_ARRAY) => {
                 include_bytes!("constant.frag.spv").to_vec()
             }
-            _ => {
-                panic!(
-                    "Graphics adapter does not support any of the features needed for this example"
-                );
-            }
+            _ => unreachable!(),
         };
         let fs_module = device.create_shader_module(wgpu::util::make_spirv(&fs_bytes));
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -35,8 +35,8 @@ pub fn make_spirv<'a>(data: &'a [u8]) -> super::ShaderModuleSource<'a> {
     // otherwise copy the byte array in an owned vector and use that instead.
     let words = if data.as_ptr().align_offset(align_of::<u32>()) == 0 {
         let (pre, words, post) = unsafe { data.align_to::<u32>() };
-        debug_assert_eq!(pre, &[]);
-        debug_assert_eq!(post, &[]);
+        debug_assert!(pre.is_empty());
+        debug_assert!(post.is_empty());
         Cow::from(words)
     } else {
         let mut words = vec![0u32; data.len() / size_of::<u32>()];


### PR DESCRIPTION
Requiring individual examples be responsible for panicing if their features aren't supported is a bit bug-prone, so this encodes requirements in the framework and enforces it in the framework.

Additionally made the verbs consistent.