### PR TITLE
Fix the link to friend applications in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For now, the shaders can be compiled to SPIR-V by running `make`, which requires
 
 ## Friends
 
-See [our wiki](https://github.com/gfx-rs/wgpu-rs/wiki/Applications) for the list of libraries and applications using `wgpu`.
+See [our wiki](https://github.com/gfx-rs/wgpu-rs/wiki/Applications-and-Libraries) for the list of libraries and applications using `wgpu`.
 
 ## Development
 


### PR DESCRIPTION
The current link <sup> [1] </sup> brings one to a "Create new page" form for the wiki instead of the intended page <sup> [2] </sup>.
[1] https://github.com/gfx-rs/wgpu-rs/wiki/Applications
[2] https://github.com/gfx-rs/wgpu-rs/wiki/Applications-and-Libraries