### PR TITLE
Enable features in CI to prevent compiler errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,18 +19,18 @@ jobs:
         include:
           - os: macos-10.15
             wasm: false
-            CHECK_COMMAND: cargo check --all-targets --features vulkan-portability
+            CHECK_COMMAND: cargo check --all-targets --all-features
             TEST_COMMAND: cargo test --all-targets --no-run
           - os: ubuntu-18.04
             wasm: false
-            CHECK_COMMAND: cargo check --all-targets
+            CHECK_COMMAND: cargo check --all-targets --all-features
             TEST_COMMAND: cargo test --all-targets --no-run
           - os: windows-2019
             wasm: false
-            CHECK_COMMAND: rustup default stable-msvc && cargo check --all-targets
+            CHECK_COMMAND: rustup default stable-msvc && cargo check --all-targets --all-features
             TEST_COMMAND: rustup default stable-msvc && cargo test --all-targets --no-run
           - wasm: true
-            CHECK_COMMAND: rustup target add wasm32-unknown-unknown && cargo check --all-targets --target=wasm32-unknown-unknown
+            CHECK_COMMAND: rustup target add wasm32-unknown-unknown && cargo check --all-targets --all-features --target=wasm32-unknown-unknown
             TEST_COMMAND: rustup target add wasm32-unknown-unknown && cargo test --all-targets --no-run --target=wasm32-unknown-unknown
             RUSTFLAGS: --cfg=web_sys_unstable_apis
     steps:

--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -72,7 +72,7 @@ struct Setup {
 }
 
 async fn setup<E: Example>(title: &str) -> Setup {
-    #[cfg(feature = "subscriber")]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "subscriber"))]
     {
         let chrome_tracing_dir = std::env::var("WGPU_CHROME_TRACE");
         wgpu::util::initialize_default_subscriber(


### PR DESCRIPTION
Simple change, this also builds features in CI.

I added trace and replay features to wasm, even though wasm doesn't support tracing as is, because people may enable them to get serde support for wgpu-types stuff.