### PR TITLE
Expose get_bind_group_layout

### DIFF
--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -1042,6 +1042,23 @@ impl crate::Context for Context {
         wgc::gfx_select!(*pipeline => global.render_pipeline_drop(*pipeline))
     }
 
+    fn compute_pipeline_get_bind_group_layout(
+        &self,
+        pipeline: &Self::ComputePipelineId,
+        index: u32,
+    ) -> Self::BindGroupLayoutId {
+        let global = &self.0;
+        wgc::gfx_select!(*pipeline => global.compute_pipeline_get_bind_group_layout(*pipeline, index)).unwrap()
+    }
+    fn render_pipeline_get_bind_group_layout(
+        &self,
+        pipeline: &Self::RenderPipelineId,
+        index: u32,
+    ) -> Self::BindGroupLayoutId {
+        let global = &self.0;
+        wgc::gfx_select!(*pipeline => global.render_pipeline_get_bind_group_layout(*pipeline, index)).unwrap()
+    }
+
     fn command_encoder_copy_buffer_to_buffer(
         &self,
         encoder: &Self::CommandEncoderId,

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -1254,6 +1254,21 @@ impl crate::Context for Context {
         // Dropped automatically
     }
 
+    fn compute_pipeline_get_bind_group_layout(
+        &self,
+        _pipeline: &Self::ComputePipelineId,
+        _index: u32,
+    ) -> Self::BindGroupLayoutId {
+        unimplemented!()
+    }
+    fn render_pipeline_get_bind_group_layout(
+        &self,
+        _pipeline: &Self::RenderPipelineId,
+        _index: u32,
+    ) -> Self::BindGroupLayoutId {
+        unimplemented!()
+    }
+
     fn command_encoder_copy_buffer_to_buffer(
         &self,
         encoder: &Self::CommandEncoderId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,6 +306,17 @@ trait Context: Debug + Send + Sized + Sync {
     fn compute_pipeline_drop(&self, pipeline: &Self::ComputePipelineId);
     fn render_pipeline_drop(&self, pipeline: &Self::RenderPipelineId);
 
+    fn compute_pipeline_get_bind_group_layout(
+        &self,
+        pipeline: &Self::ComputePipelineId,
+        index: u32,
+    ) -> Self::BindGroupLayoutId;
+    fn render_pipeline_get_bind_group_layout(
+        &self,
+        pipeline: &Self::RenderPipelineId,
+        index: u32,
+    ) -> Self::BindGroupLayoutId;
+
     fn command_encoder_copy_buffer_to_buffer(
         &self,
         encoder: &Self::CommandEncoderId,
@@ -682,6 +693,19 @@ impl Drop for RenderPipeline {
     }
 }
 
+impl RenderPipeline {
+    /// Get an object representing the bind group layout at a given index.
+    pub fn get_bind_group_layout(&self, index: u32) -> BindGroupLayout {
+        let context = Arc::clone(&self.context);
+        BindGroupLayout {
+            context,
+            id: self
+                .context
+                .render_pipeline_get_bind_group_layout(&self.id, index),
+        }
+    }
+}
+
 /// Handle to a compute pipeline.
 ///
 /// A `ComputePipeline` object represents a compute pipeline and its single shader stage.
@@ -696,6 +720,19 @@ impl Drop for ComputePipeline {
     fn drop(&mut self) {
         if !thread::panicking() {
             self.context.compute_pipeline_drop(&self.id);
+        }
+    }
+}
+
+impl ComputePipeline {
+    /// Get an object representing the bind group layout at a given index.
+    pub fn get_bind_group_layout(&self, index: u32) -> BindGroupLayout {
+        let context = Arc::clone(&self.context);
+        BindGroupLayout {
+            context,
+            id: self
+                .context
+                .compute_pipeline_get_bind_group_layout(&self.id, index),
         }
     }
 }


### PR DESCRIPTION
Returning a new object is fine for BGLs specifically and for these cases in particular because we made sure the refcount is bumped (and BGL has a special kind of refcount) in https://github.com/gfx-rs/wgpu/commit/f164fd1f46390d6a51acc1c1082cc8e0c23dbb8c