### PR TITLE
Expose debug marker/groups for ComputePass and Encoder

### DIFF
--- a/examples/boids/main.rs
+++ b/examples/boids/main.rs
@@ -279,6 +279,7 @@ impl framework::Example for Example {
         let mut command_encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
 
+        command_encoder.push_debug_group("compute boid movement");
         {
             // compute pass
             let mut cpass = command_encoder.begin_compute_pass();
@@ -286,7 +287,9 @@ impl framework::Example for Example {
             cpass.set_bind_group(0, &self.particle_bind_groups[self.frame_num % 2], &[]);
             cpass.dispatch(self.work_group_count, 1, 1);
         }
+        command_encoder.pop_debug_group();
 
+        command_encoder.push_debug_group("render boids");
         {
             // render pass
             let mut rpass = command_encoder.begin_render_pass(&render_pass_descriptor);
@@ -297,6 +300,7 @@ impl framework::Example for Example {
             rpass.set_vertex_buffer(1, self.vertices_buffer.slice(..));
             rpass.draw(0..3, 0..NUM_PARTICLES);
         }
+        command_encoder.pop_debug_group();
 
         // update frame count
         self.frame_num += 1;

--- a/examples/hello-compute/main.rs
+++ b/examples/hello-compute/main.rs
@@ -134,6 +134,7 @@ async fn execute_gpu(numbers: Vec<u32>) -> Vec<u32> {
         let mut cpass = encoder.begin_compute_pass();
         cpass.set_pipeline(&compute_pipeline);
         cpass.set_bind_group(0, &bind_group, &[]);
+        cpass.insert_debug_marker("compute collatz iterations");
         cpass.dispatch(numbers.len() as u32, 1, 1); // Number of cells to run, the (x,y,z) size of item being processed
     }
     // Sets adds copy operation to command encoder.

--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -96,6 +96,22 @@ mod pass_impl {
                 )
             }
         }
+        fn insert_debug_marker(&mut self, label: &str) {
+            unsafe {
+                let label = std::ffi::CString::new(label).unwrap();
+                wgpu_compute_pass_insert_debug_marker(self, label.as_ptr().into(), 0);
+            }
+        }
+
+        fn push_debug_group(&mut self, group_label: &str) {
+            unsafe {
+                let label = std::ffi::CString::new(group_label).unwrap();
+                wgpu_compute_pass_push_debug_group(self, label.as_ptr().into(), 0);
+            }
+        }
+        fn pop_debug_group(&mut self) {
+            wgpu_compute_pass_pop_debug_group(self);
+        }
         fn dispatch(&mut self, x: u32, y: u32, z: u32) {
             wgpu_compute_pass_dispatch(self, x, y, z)
         }
@@ -1242,6 +1258,22 @@ impl crate::Context for Context {
         let desc = wgt::CommandBufferDescriptor::default();
         let global = &self.0;
         wgc::gfx_select!(*encoder => global.command_encoder_finish(*encoder, &desc)).unwrap_pretty()
+    }
+
+    fn command_encoder_insert_debug_marker(&self, encoder: &Self::CommandEncoderId, label: &str) {
+        let global = &self.0;
+        wgc::gfx_select!(*encoder => global.command_encoder_insert_debug_marker(*encoder, &label))
+            .unwrap_pretty()
+    }
+    fn command_encoder_push_debug_group(&self, encoder: &Self::CommandEncoderId, label: &str) {
+        let global = &self.0;
+        wgc::gfx_select!(*encoder => global.command_encoder_push_debug_group(*encoder, &label))
+            .unwrap_pretty()
+    }
+    fn command_encoder_pop_debug_group(&self, encoder: &Self::CommandEncoderId) {
+        let global = &self.0;
+        wgc::gfx_select!(*encoder => global.command_encoder_pop_debug_group(*encoder))
+            .unwrap_pretty()
     }
 
     fn render_bundle_encoder_finish(

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -88,6 +88,19 @@ impl crate::ComputePassInner<Context> for ComputePass {
     fn set_push_constants(&mut self, _offset: u32, _data: &[u32]) {
         panic!("PUSH_CONSTANTS feature must be enabled to call multi_draw_indexed_indirect")
     }
+
+    fn insert_debug_marker(&mut self, _label: &str) {
+        unimplemented!()
+    }
+
+    fn push_debug_group(&mut self, _group_label: &str) {
+        unimplemented!()
+    }
+
+    fn pop_debug_group(&mut self) {
+        unimplemented!()
+    }
+
     fn dispatch(&mut self, x: u32, y: u32, z: u32) {
         self.0.dispatch_with_y_and_z(x, y, z);
     }
@@ -1434,6 +1447,16 @@ impl crate::Context for Context {
             mapped_desc.label(label);
         }
         Sendable(encoder.finish_with_descriptor(&mapped_desc))
+    }
+
+    fn command_encoder_insert_debug_marker(&self, encoder: &Self::CommandEncoderId, label: &str) {
+        unimplemented!()
+    }
+    fn command_encoder_push_debug_group(&self, encoder: &Self::CommandEncoderId, label: &str) {
+        unimplemented!()
+    }
+    fn command_encoder_pop_debug_group(&self, encoder: &Self::CommandEncoderId) {
+        unimplemented!()
     }
 
     fn render_bundle_encoder_finish(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,9 @@ trait ComputePassInner<Ctx: Context> {
         offsets: &[DynamicOffset],
     );
     fn set_push_constants(&mut self, offset: u32, data: &[u32]);
+    fn insert_debug_marker(&mut self, label: &str);
+    fn push_debug_group(&mut self, group_label: &str);
+    fn pop_debug_group(&mut self);
     fn dispatch(&mut self, x: u32, y: u32, z: u32);
     fn dispatch_indirect(
         &mut self,
@@ -368,6 +371,11 @@ trait Context: Debug + Send + Sized + Sync {
         pass: &mut Self::RenderPassId,
     );
     fn command_encoder_finish(&self, encoder: &Self::CommandEncoderId) -> Self::CommandBufferId;
+
+    fn command_encoder_insert_debug_marker(&self, encoder: &Self::CommandEncoderId, label: &str);
+    fn command_encoder_push_debug_group(&self, encoder: &Self::CommandEncoderId, label: &str);
+    fn command_encoder_pop_debug_group(&self, encoder: &Self::CommandEncoderId);
+
     fn render_bundle_encoder_finish(
         &self,
         encoder: Self::RenderBundleEncoderId,
@@ -1905,6 +1913,21 @@ impl CommandEncoder {
             copy_size,
         );
     }
+
+    /// Inserts debug marker.
+    pub fn insert_debug_marker(&mut self, label: &str) {
+        Context::command_encoder_insert_debug_marker(&*self.context, &self.id, label);
+    }
+
+    /// Start record commands and group it into debug marker group.
+    pub fn push_debug_group(&mut self, label: &str) {
+        Context::command_encoder_push_debug_group(&*self.context, &self.id, label);
+    }
+
+    /// Stops command recording and creates debug group.
+    pub fn pop_debug_group(&mut self) {
+        Context::command_encoder_pop_debug_group(&*self.context, &self.id);
+    }
 }
 
 impl<'a> RenderPass<'a> {
@@ -2295,6 +2318,21 @@ impl<'a> ComputePass<'a> {
     /// Sets the active compute pipeline.
     pub fn set_pipeline(&mut self, pipeline: &'a ComputePipeline) {
         ComputePassInner::set_pipeline(&mut self.id, &pipeline.id);
+    }
+
+    /// Inserts debug marker.
+    pub fn insert_debug_marker(&mut self, label: &str) {
+        self.id.insert_debug_marker(label);
+    }
+
+    /// Start record commands and group it into debug marker group.
+    pub fn push_debug_group(&mut self, label: &str) {
+        self.id.push_debug_group(label);
+    }
+
+    /// Stops command recording and creates debug group.
+    pub fn pop_debug_group(&mut self) {
+        self.id.pop_debug_group();
     }
 
     /// Dispatches compute work operations.


### PR DESCRIPTION
Added uses of them to the examples to make sure everything compiles & works.
Marker on compute examples are arguably a bit awkward since they are so trivial. On the shadow example however it is a delight when inspected in RenderDoc! (and it will do wonders to my project which can run into situations with literally thousands of compute dispatches per frame 😅 )

RenderDoc, boids example:
![0_boids](https://user-images.githubusercontent.com/1220815/90963818-70c1fc80-e4bb-11ea-9842-25240ae5c927.png)

RenderDoc, shadow example:
![1_shadow](https://user-images.githubusercontent.com/1220815/90963819-728bc000-e4bb-11ea-9395-630a1f7b3a31.png)
