### PR TITLE
Removed erroneous zero size check related conditional in water example resize()

### DIFF
--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -250,8 +250,8 @@ fn start<E: Example>(
                 ..
             } => {
                 log::info!("Resizing to {:?}", size);
-                sc_desc.width = size.width;
-                sc_desc.height = size.height;
+                sc_desc.width = if size.width == 0 { 1 } else { size.width };
+                sc_desc.height = if size.height == 0 { 1 } else { size.height };
                 example.resize(&sc_desc, &device, &queue);
                 swap_chain = device.create_swap_chain(&surface, &sc_desc);
             }

--- a/examples/water/main.rs
+++ b/examples/water/main.rs
@@ -648,13 +648,8 @@ impl framework::Example for Example {
             // Stop rendering altogether.
             self.active = None;
             return;
-        } else {
-            // The next frame queued is the wrong size: (0, 0),
-            // so we skip a frame to avoid crashes where our
-            // textures are the correct (window) size, and the
-            // frame is still (0, 0).
-            self.active = Some(self.current_frame + 1);
         }
+        self.active = Some(self.current_frame);
 
         // Regenerate all of the buffers and textures.
 


### PR DESCRIPTION
The conditional at the start of resize() already tests for and exits on the zero width and height condition.

The conditional removed here was then getting run on every other call to resize(), which doesn't seem logical, doesn't correspond to the comment, and seemed to be causing at least one issue with rendered viewport going black during resize.

Fixes #532
(probably) Fixes #519