### PR TITLE
Don't use `log` crate in include_spirv

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -48,7 +48,7 @@ fn test_vertex_attr_array() {
 macro_rules! include_spirv {
     ($($token:tt)*) => {
         {
-            log::info!("including '{}'", $($token)*);
+            //log::info!("including '{}'", $($token)*);
             $crate::util::make_spirv(include_bytes!($($token)*))
         }
     };


### PR DESCRIPTION
Fixes  #541