### PR TITLE
Implement on_uncaptured_error 

### DIFF
--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -930,6 +930,14 @@ impl crate::Context for Context {
         .unwrap_pretty()
     }
 
+    fn device_on_uncaptured_error(
+        &self,
+        _device: &Self::DeviceId,
+        _handler: impl crate::UncapturedErrorHandler,
+    ) {
+        todo!();
+    }
+
     fn buffer_map_async(
         &self,
         buffer: &Self::BufferId,

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -1148,6 +1148,14 @@ impl crate::Context for Context {
         // Device is polled automatically
     }
 
+    fn device_on_uncaptured_error(
+        &self,
+        _device: &Self::DeviceId,
+        _handler: impl crate::UncapturedErrorHandler,
+    ) {
+        // TODO:
+    }
+
     fn buffer_map_async(
         &self,
         _buffer: &Self::BufferId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod macros;
 
 use std::{
     borrow::Cow,
-    error::Error,
+    error,
     fmt::{Debug, Display},
     future::Future,
     marker::PhantomData,
@@ -1266,7 +1266,7 @@ impl Display for SwapChainError {
     }
 }
 
-impl Error for SwapChainError {}
+impl error::Error for SwapChainError {}
 
 impl Instance {
     /// Create an new instance of wgpu.
@@ -1562,7 +1562,7 @@ impl Display for RequestDeviceError {
     }
 }
 
-impl Error for RequestDeviceError {}
+impl error::Error for RequestDeviceError {}
 
 /// Error occurred when trying to async map a buffer.
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -1574,7 +1574,7 @@ impl Display for BufferAsyncError {
     }
 }
 
-impl Error for BufferAsyncError {}
+impl error::Error for BufferAsyncError {}
 
 /// Type of buffer mapping.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2636,11 +2636,21 @@ pub enum Error {
         source: Box<dyn error::Error + Send + Sync + 'static>,
     },
 }
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Error::OutOfMemoryError => None,
+            Error::ValidationError { source } => Some(source.as_ref()),
+        }
+    }
+}
+
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::OutOfMemoryError => f.write_str("Out of Memory"),
-            Error::ValidationError { source } => std::fmt::Display::fmt(source, f),
+            Error::ValidationError { .. } => f.write_str("Validation error"),
         }
     }
 }


### PR DESCRIPTION
This is very crude at the moment, I'm mostly just checking if the directions is at all viable.

So I set out to implement `on_caught_error`, focusing solely on the direct backend. It just accepts a `Fn(GPUError)` (and I named it GPUError because I didn't yet want to rename the import of `std::error::Error`).

I store the handler in a `ErrorSinkRaw` struct, which is then wrapped in Arc+Mutex, with the idea that other resources can point to the same Arc, so when `Device::on_uncaught_error` is called mid application, all resources will point to the right place. Otherwise I think something like `Buffer::unmap` would have to find the `Device` it was created with, to find the uncaught handler.

Now I store the `ErrorSink` in the `Device` struct, because it is a convenient place to hold it. But I guess it is a bit nonsensical with the web backend, so either it would need to be `cfg(not(wasm32))`, or move the whole thing in the backend side, but in the direct backend, I don't see a convenient place to store the closure. But the unwrapping is done in direct backend, so it can't really be moved up in to wgpu-core either, unless the error handling overall is moved there.

Also related, I'm now passing the `error_sink` argument to the few methods where I implemented the error handling, which I think is a bit ugly, but it works.