### PR TITLE
Replace unsafe impl Pod with safe derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ log = "0.4"
 png = "0.16"
 winit = { version = "0.22.1", features = ["web-sys"] }
 rand = { version = "0.7.2", features = ["wasm-bindgen"] }
-bytemuck = "1"
+bytemuck = { version = "1.4", features = ["derive"] }
 noise = "0.6"
 ddsfile = "0.4"
 futures = { version = "0.3", default-features = false, features = ["std", "executor"] }

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -5,14 +5,11 @@ use bytemuck::{Pod, Zeroable};
 use wgpu::util::DeviceExt;
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Pod, Zeroable)]
 struct Vertex {
     _pos: [f32; 4],
     _tex_coord: [f32; 2],
 }
-
-unsafe impl Pod for Vertex {}
-unsafe impl Zeroable for Vertex {}
 
 fn vertex(pos: [i8; 3], tc: [i8; 2]) -> Vertex {
     Vertex {

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -8,14 +8,11 @@ use wgpu::util::DeviceExt;
 const TEXTURE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Pod, Zeroable)]
 struct Vertex {
     #[allow(dead_code)]
     pos: [f32; 4],
 }
-
-unsafe impl Pod for Vertex {}
-unsafe impl Zeroable for Vertex {}
 
 fn create_vertices() -> Vec<Vertex> {
     vec![

--- a/examples/msaa-line/main.rs
+++ b/examples/msaa-line/main.rs
@@ -16,14 +16,11 @@ use bytemuck::{Pod, Zeroable};
 use wgpu::util::DeviceExt;
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Pod, Zeroable)]
 struct Vertex {
     _pos: [f32; 2],
     _color: [f32; 4],
 }
-
-unsafe impl Pod for Vertex {}
-unsafe impl Zeroable for Vertex {}
 
 struct Example {
     bundle: wgpu::RenderBundle,

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -7,15 +7,11 @@ use bytemuck::{Pod, Zeroable};
 use wgpu::util::DeviceExt;
 
 #[repr(C)]
-#[derive(Clone, Copy)]
-
+#[derive(Clone, Copy, Pod, Zeroable)]
 struct Vertex {
     _pos: [i8; 4],
     _normal: [i8; 4],
 }
-
-unsafe impl Pod for Vertex {}
-unsafe impl Zeroable for Vertex {}
 
 fn vertex(pos: [i8; 3], nor: [i8; 3]) -> Vertex {
     Vertex {
@@ -102,15 +98,12 @@ struct Light {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Pod, Zeroable)]
 struct LightRaw {
     proj: [[f32; 4]; 4],
     pos: [f32; 4],
     color: [f32; 4],
 }
-
-unsafe impl Pod for LightRaw {}
-unsafe impl Zeroable for LightRaw {}
 
 impl Light {
     fn to_raw(&self) -> LightRaw {
@@ -140,24 +133,18 @@ impl Light {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Pod, Zeroable)]
 struct ForwardUniforms {
     proj: [[f32; 4]; 4],
     num_lights: [u32; 4],
 }
 
-unsafe impl Pod for ForwardUniforms {}
-unsafe impl Zeroable for ForwardUniforms {}
-
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Pod, Zeroable)]
 struct EntityUniforms {
     model: [[f32; 4]; 4],
     color: [f32; 4],
 }
-
-unsafe impl Pod for EntityUniforms {}
-unsafe impl Zeroable for EntityUniforms {}
 
 #[repr(C)]
 struct ShadowUniforms {

--- a/examples/texture-arrays/main.rs
+++ b/examples/texture-arrays/main.rs
@@ -6,24 +6,18 @@ use bytemuck::{Pod, Zeroable};
 use wgpu::util::DeviceExt;
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Pod, Zeroable)]
 struct Vertex {
     _pos: [f32; 2],
     _tex_coord: [f32; 2],
     _index: u32,
 }
 
-unsafe impl Pod for Vertex {}
-unsafe impl Zeroable for Vertex {}
-
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Pod, Zeroable)]
 struct Uniform {
     index: u32,
 }
-
-unsafe impl Pod for Uniform {}
-unsafe impl Zeroable for Uniform {}
 
 fn vertex(pos: [i8; 2], tc: [i8; 2], index: i8) -> Vertex {
     Vertex {

--- a/examples/water/main.rs
+++ b/examples/water/main.rs
@@ -6,6 +6,7 @@ mod point_gen;
 use cgmath::Point3;
 use std::{iter, mem};
 use wgpu::util::DeviceExt;
+use bytemuck::{Pod, Zeroable};
 
 ///
 /// Radius of the terrain.
@@ -34,17 +35,14 @@ struct Matrices {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Pod, Zeroable)]
 struct TerrainUniforms {
     view_projection: [f32; 16],
     clipping_plane: [f32; 4],
 }
 
-unsafe impl bytemuck::Zeroable for TerrainUniforms {}
-unsafe impl bytemuck::Pod for TerrainUniforms {}
-
 #[repr(C)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Pod, Zeroable)]
 struct WaterUniforms {
     view: [f32; 16],
     projection: [f32; 16],
@@ -57,9 +55,6 @@ struct Uniforms {
     terrain_flipped: TerrainUniforms,
     water: WaterUniforms,
 }
-
-unsafe impl bytemuck::Zeroable for WaterUniforms {}
-unsafe impl bytemuck::Pod for WaterUniforms {}
 
 struct Example {
     water_vertex_buf: wgpu::Buffer,

--- a/examples/water/point_gen.rs
+++ b/examples/water/point_gen.rs
@@ -3,6 +3,7 @@
 //!
 
 use cgmath::{InnerSpace, Point3, Vector3};
+use bytemuck::{Pod, Zeroable};
 use std::collections::HashMap;
 
 // The following constants are used in calculations.
@@ -32,27 +33,19 @@ const C45: f32 = S45;
 const SQRT_3: f32 = 1.73205080757;
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Pod, Zeroable)]
 pub struct TerrainVertexAttributes {
     position: [f32; 3],
     normal: [f32; 3],
     colour: [u8; 4],
 }
 
-unsafe impl bytemuck::Pod for TerrainVertexAttributes {}
-
-unsafe impl bytemuck::Zeroable for TerrainVertexAttributes {}
-
 #[repr(C)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Pod, Zeroable)]
 pub struct WaterVertexAttributes {
     position: [i16; 2],
     offsets: [i8; 4],
 }
-
-unsafe impl bytemuck::Pod for WaterVertexAttributes {}
-
-unsafe impl bytemuck::Zeroable for WaterVertexAttributes {}
 
 ///
 /// Represents the center of a single hexagon.


### PR DESCRIPTION
bytemuck now includes derives that will implement the Pod trait, failing to compile if the struct cannot safely be a Pod.
Lets use it to remove most of the unsafe usage from the examples.
closes https://github.com/gfx-rs/wgpu-rs/issues/190