### PR TITLE
Update to latest web-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,8 +96,8 @@ test = true
 objc = "0.2.7"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2.62"
-web-sys = { version = "0.3.39", features = [
+wasm-bindgen = "0.2.68"
+web-sys = { version = "0.3.45", features = [
     "Document",
     "Navigator",
     "Node",
@@ -170,6 +170,7 @@ web-sys = { version = "0.3.39", features = [
     "GpuTextureAspect",
     "GpuTextureComponentType",
     "GpuTextureCopyView",
+    "GpuTextureDataLayout",
     "GpuTextureDescriptor",
     "GpuTextureDimension",
     "GpuTextureFormat",
@@ -184,8 +185,8 @@ web-sys = { version = "0.3.39", features = [
     "HtmlCanvasElement",
     "Window",
 ]}
-js-sys = "0.3.39"
-wasm-bindgen-futures = "0.4.12"
+js-sys = "0.3.45"
+wasm-bindgen-futures = "0.4.18"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 console_error_panic_hook = "0.1.6"


### PR DESCRIPTION
Cherry-pick #497 into `master` now that new versions of web-sys/wasm-bindgen/js-sys/wasm-bindgen-futures are published.

We could also do this for `v0.6` too if we want CI to succeed there, or alternatively consider disabling CI for wasm builds on `v0.6`.