### PR TITLE
Pin web-sys version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,8 +96,8 @@ test = true
 objc = "0.2.7"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2.68"
-web-sys = { version = "0.3.45", features = [
+wasm-bindgen = "=0.2.68" # remember to change version in readme as well
+web-sys = { version = "=0.3.45", features = [
     "Document",
     "Navigator",
     "Node",

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To run examples on the `wasm32-unknown-unknown` target, first build the example 
 # Checkout `gecko` branch that matches the state of Firefox
 git checkout upstream/gecko
 # Install or update wasm-bindgen-cli
-cargo install -f wasm-bindgen-cli
+cargo install -f wasm-bindgen-cli --version 0.2.68
 # Build with the wasm target
 RUSTFLAGS=--cfg=web_sys_unstable_apis cargo build --target wasm32-unknown-unknown --example hello-triangle
 # Generate bindings in a `target/generated` directory


### PR DESCRIPTION
As mentioned in https://github.com/gfx-rs/wgpu-rs/pull/553 this will prevent the wasm build from breaking.
@grovesNL Is pinning just web-sys and wasm-bindgen sufficient?