### PR TITLE
Notes on LoadOp

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -885,6 +885,8 @@ pub enum BindingResource<'a> {
 }
 
 /// Operation to perform to the output attachment at the start of a renderpass.
+///
+/// The render target must be cleared at least once before it's content be loaded.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "trace", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]


### PR DESCRIPTION
If the swapchain image was drawn with a pipeline that loads a render target that has not been cleared before, the validation layer gives a triplet of confusing feedbacks:

```log
[2020-09-15T06:42:23Z ERROR gfx_backend_vulkan] 
    VALIDATION [UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout (1303270965)] : Validation Error: [ UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout ] Object 0: handle = 0x1d80787bfe8, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x4dae5635 | Submitted command buffer expects VkImage 0x6dc7200000000005[] (subresource: aspectMask 0x1 array layer 0, mip level 0) to be in layout VK_IMAGE_LAYOUT_PRESENT_SRC_KHR--instead, current layout is VK_IMAGE_LAYOUT_UNDEFINED.
    object info: (type: COMMAND_BUFFER, hndl: 2027350900712)

[2020-09-15T06:42:23Z ERROR gfx_backend_vulkan] 
    VALIDATION [UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout (1303270965)] : Validation Error: [ UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout ] Object 0: handle = 0x1d8078586a8, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x4dae5635 | Submitted command buffer expects VkImage 0x3ba5830000000006[] (subresource: aspectMask 0x1 array layer 0, mip level 0) to be in layout VK_IMAGE_LAYOUT_PRESENT_SRC_KHR--instead, current layout is VK_IMAGE_LAYOUT_UNDEFINED.
    object info: (type: COMMAND_BUFFER, hndl: 2027350754984)

[2020-09-15T06:42:23Z ERROR gfx_backend_vulkan] 
    VALIDATION [UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout (1303270965)] : Validation Error: [ UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout ] Object 0: handle = 0x1d8078614f8, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x4dae5635 | Submitted command buffer expects VkImage 0x4c5b620000000007[] (subresource: aspectMask 0x1 array layer 0, mip level 0) to be in layout VK_IMAGE_LAYOUT_PRESENT_SRC_KHR--instead, current layout is VK_IMAGE_LAYOUT_UNDEFINED.
    object info: (type: COMMAND_BUFFER, hndl: 2027350791416)
```

And it turns out they come from the triple-buffering swapchain images. It seems `wgpu` would only re-layout the swapchain image if it's been loaded by a clear op. I would be great to warn the users beforehand. (I know it's not something I should ever do tho)