### PR TITLE
web: temporarily polyfill `create_buffer_init`

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -74,21 +74,33 @@ impl DeviceExt for crate::Device {
         let mut map_context = crate::MapContext::new(padded_size);
 
         map_context.initial_range = 0..padded_size;
+
+        #[cfg(target_arch = "wasm32")]
         let buffer = crate::Buffer {
             context: Arc::clone(&self.context),
-            id: crate::Context::device_create_buffer(&*self.context, &self.id, &wgt_descriptor),
+            id: crate::backend::Context::create_buffer_init_polyfill(&self.id, &wgt_descriptor, descriptor.contents),
             map_context: parking_lot::Mutex::new(map_context),
             usage: descriptor.usage,
         };
-
-        let range =
-            crate::Context::buffer_get_mapped_range_mut(&*self.context, &buffer.id, 0..padded_size);
-        range[0..unpadded_size as usize].copy_from_slice(descriptor.contents);
-        for i in unpadded_size..padded_size {
-            range[i as usize] = 0;
-        }
-
-        buffer.unmap();
+        #[cfg(not(target_arch = "wasm32"))]
+        let buffer = {
+            let buffer = crate::Buffer {
+                context: Arc::clone(&self.context),
+                id: crate::Context::device_create_buffer(&*self.context, &self.id, &wgt_descriptor),
+                map_context: parking_lot::Mutex::new(map_context),
+                usage: descriptor.usage,
+            };
+    
+            let range =
+                crate::Context::buffer_get_mapped_range_mut(&*self.context, &buffer.id, 0..padded_size);
+            range[0..unpadded_size as usize].copy_from_slice(descriptor.contents);
+            for i in unpadded_size..padded_size {
+                range[i as usize] = 0;
+            }
+    
+            buffer.unmap();
+            buffer
+        };
         buffer
     }
 }


### PR DESCRIPTION
Temporarily polyfill `create_buffer_init` on the web backend by using the old buffer mapping API. This is just a temporary fix until the new buffer mapping API is available in Nightly.

This polyfill allows us to run `cube` from `master` on Nightly (there's still lots missing from other examples). But at least some simple use cases (e.g. projects only using `create_buffer_init`/`write_buffer` and no other buffer mapping functions) can run with `master`.