### PR TITLE
Implement AsRef for BufferView

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1658,6 +1658,18 @@ impl std::ops::DerefMut for BufferViewMut<'_> {
     }
 }
 
+impl AsRef<[u8]> for BufferView<'_> {
+    fn as_ref(&self) -> &[u8] {
+        self.data
+    }
+}
+
+impl AsMut<[u8]> for BufferViewMut<'_> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.data
+    }
+}
+
 impl Drop for BufferView<'_> {
     fn drop(&mut self) {
         self.slice


### PR DESCRIPTION
This PR implements `AsRef` and `AsMut` in addition to `Deref` and `DerefMut` for `BufferView` and `BufferViewMut`.

This allows the buffer views to be used directly by generic code that wants an `AsRef<[u8]>`.

It's also subjectively a small win when you want to pass the views to non-generic code. I find `buffer.as_ref()` clearer than `&*buffer`. That also goes for `buffer.deref()`, but `Deref` is not in the prelude.