### PR TITLE
Convert swapchain.get_current_frame to a immutable reference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2599,7 +2599,7 @@ impl SwapChain {
     ///
     /// If a SwapChainFrame referencing this surface is alive when the swapchain is recreated,
     /// recreating the swapchain will panic.
-    pub fn get_current_frame(&mut self) -> Result<SwapChainFrame, SwapChainError> {
+    pub fn get_current_frame(&self) -> Result<SwapChainFrame, SwapChainError> {
         let (view_id, status, detail) =
             Context::swap_chain_get_current_texture_view(&*self.context, &self.id);
         let output = view_id.map(|id| SwapChainTexture {


### PR DESCRIPTION
Per our discussion on matrix, converts swapchain.get_current_frame to an immutable reference as it's internally synchronized.

Rationale: will allow me to take a non-pretty RW mutex as read instead of write in my application