### PR TITLE
Fixes #575 - vulkan-portability feature on MacOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default = []
 trace = ["serde", "wgc/trace"]
 replay = ["serde", "wgc/replay"]
 # Make Vulkan backend available on platforms where it is by default not, e.g. macOS
-vulkan-portability = ["wgc/gfx-backend-vulkan"]
+vulkan-portability = ["wgc/gfx-backend-vulkan", "gfx-backend-vulkan"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgc]
 package = "wgpu-core"
@@ -94,6 +94,7 @@ test = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2.7"
+gfx-backend-vulkan = { version = "0.6", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "=0.2.68" # remember to change version in readme as well


### PR DESCRIPTION
See #575.
This PR fixes the issue with enabling `vulkan-portability` on MacOS.