### PR TITLE
[Blocked] Relax render/compute pass lifetimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ vulkan-portability = ["wgc/gfx-backend-vulkan", "gfx-backend-vulkan"]
 package = "wgpu-core"
 #version = "0.6"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "7ac706f0a9d90ebdcffeae48e3c530b9921bff2c"
+rev = "7b9abf0fef76eea363869bc940fda1783dc12bab"
 features = ["raw-window-handle"]
 
 [dependencies.wgt]
 package = "wgpu-types"
 #version = "0.6"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "7ac706f0a9d90ebdcffeae48e3c530b9921bff2c"
+rev = "7b9abf0fef76eea363869bc940fda1783dc12bab"
 
 [dependencies]
 arrayvec = "0.5"

--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -1375,10 +1375,10 @@ impl crate::Context for Context {
         .unwrap_error_sink(&encoder.error_sink, || ())
     }
 
-    fn command_encoder_begin_render_pass<'a>(
+    fn command_encoder_begin_render_pass(
         &self,
         encoder: &Self::CommandEncoderId,
-        desc: &crate::RenderPassDescriptor<'a, '_>,
+        desc: &crate::RenderPassDescriptor,
     ) -> Self::RenderPassId {
         wgc::span!(_guard, TRACE, "CommandEncoder::begin_render_pass wrapper");
         let colors = desc


### PR DESCRIPTION
Mostly reverts #168 given that `wgpu-core` is now properly handling error IDs.
Closes #603
Closes #188

Has a major positive usability impact 🚆  It is no longer required by the type system to keep resources alive for the duration of a render/compute pass encoding. It's still required by the runtime: dropping a pass will produce an error if some of the dependencies are dropped before it.

Looking at the error messages may be difficult until an approach similar to https://github.com/gfx-rs/wgpu/pull/931#issuecomment-721386402 is rolled out in wgpu-rs (cc @scoopr). We'll make it a priority before releasing wgpu-0.7.

Edit: actually, the IDs here are not "error IDs" that `wgpu-core` handles. It will panic straight upon seeing such a stale ID...