### PR TITLE
Rename TextureUsage::OUTPUT_ATTACHMENT to RENDER_ATTACHMENT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ vulkan-portability = ["wgc/gfx-backend-vulkan", "gfx-backend-vulkan"]
 package = "wgpu-core"
 #version = "0.6"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "99ff41bb998d017ca5afdf9a8657cc744dc225d3"
+rev = "789b09c7bde774f09b0cec87d6ea1b5700a6de2f"
 features = ["raw-window-handle"]
 
 [dependencies.wgt]
 package = "wgpu-types"
 #version = "0.6"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "99ff41bb998d017ca5afdf9a8657cc744dc225d3"
+rev = "789b09c7bde774f09b0cec87d6ea1b5700a6de2f"
 
 [dependencies]
 arrayvec = "0.5"

--- a/examples/capture/main.rs
+++ b/examples/capture/main.rs
@@ -71,7 +71,7 @@ async fn create_red_image_with_dimensions(
         sample_count: 1,
         dimension: wgpu::TextureDimension::D2,
         format: wgpu::TextureFormat::Rgba8UnormSrgb,
-        usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT | wgpu::TextureUsage::COPY_SRC,
+        usage: wgpu::TextureUsage::RENDER_ATTACHMENT | wgpu::TextureUsage::COPY_SRC,
         label: None,
     });
 

--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -207,7 +207,7 @@ fn start<E: Example>(
     };
 
     let mut sc_desc = wgpu::SwapChainDescriptor {
-        usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+        usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
         // TODO: Allow srgb unconditionally
         format: if cfg!(target_arch = "wasm32") {
             wgpu::TextureFormat::Bgra8Unorm

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -66,7 +66,7 @@ async fn run(event_loop: EventLoop<()>, window: Window, swapchain_format: wgpu::
     });
 
     let mut sc_desc = wgpu::SwapChainDescriptor {
-        usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+        usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
         format: swapchain_format,
         width: size.width,
         height: size.height,

--- a/examples/hello-windows/main.rs
+++ b/examples/hello-windows/main.rs
@@ -31,7 +31,7 @@ impl ViewportDesc {
         let size = self.window.inner_size();
 
         let sc_desc = wgpu::SwapChainDescriptor {
-            usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+            usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
             format: swapchain_format,
             width: size.width,
             height: size.height,

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -208,7 +208,7 @@ impl framework::Example for Example {
             dimension: wgpu::TextureDimension::D2,
             format: TEXTURE_FORMAT,
             usage: wgpu::TextureUsage::SAMPLED
-                | wgpu::TextureUsage::OUTPUT_ATTACHMENT
+                | wgpu::TextureUsage::RENDER_ATTACHMENT
                 | wgpu::TextureUsage::COPY_DST,
             label: None,
         });

--- a/examples/msaa-line/main.rs
+++ b/examples/msaa-line/main.rs
@@ -109,7 +109,7 @@ impl Example {
             sample_count: sample_count,
             dimension: wgpu::TextureDimension::D2,
             format: sc_desc.format,
-            usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+            usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
             label: None,
         };
 

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -354,7 +354,7 @@ impl framework::Example for Example {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: Self::SHADOW_FORMAT,
-            usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT | wgpu::TextureUsage::SAMPLED,
+            usage: wgpu::TextureUsage::RENDER_ATTACHMENT | wgpu::TextureUsage::SAMPLED,
             label: None,
         });
         let shadow_view = shadow_texture.create_view(&wgpu::TextureViewDescriptor::default());
@@ -641,7 +641,7 @@ impl framework::Example for Example {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: Self::DEPTH_FORMAT,
-            usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+            usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
             label: None,
         });
 
@@ -687,7 +687,7 @@ impl framework::Example for Example {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: Self::DEPTH_FORMAT,
-            usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+            usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
             label: None,
         });
         self.forward_depth = depth_texture.create_view(&wgpu::TextureViewDescriptor::default());

--- a/examples/water/main.rs
+++ b/examples/water/main.rs
@@ -199,7 +199,7 @@ impl Example {
             format: sc_desc.format,
             usage: wgpu::TextureUsage::SAMPLED
                 | wgpu::TextureUsage::COPY_DST
-                | wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+                | wgpu::TextureUsage::RENDER_ATTACHMENT,
         });
 
         let draw_depth_buffer = device.create_texture(&wgpu::TextureDescriptor {
@@ -211,7 +211,7 @@ impl Example {
             format: wgpu::TextureFormat::Depth32Float,
             usage: wgpu::TextureUsage::SAMPLED
                 | wgpu::TextureUsage::COPY_DST
-                | wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+                | wgpu::TextureUsage::RENDER_ATTACHMENT,
         });
 
         let sampler = device.create_sampler(&wgpu::SamplerDescriptor {


### PR DESCRIPTION
Depends on https://github.com/gfx-rs/wgpu/pull/1017 