### PR TITLE
Bump winit version to 0.23.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ gfx-backend-gl = { version = "0.6", features = ["x11"] }
 cgmath = "0.17"
 log = "0.4"
 png = "0.16"
-winit = { version = "0.22.1", features = ["web-sys"] }
+winit = { version = "0.23.0", features = ["web-sys"] }
 rand = { version = "0.7.2", features = ["wasm-bindgen"] }
 bytemuck = { version = "1.4", features = ["derive"] }
 noise = "0.6"


### PR DESCRIPTION
This fixes the following error trying to run the hello-triangle (and probably other) examples on GNOME/Wayland:

    [wayland-client error] Attempted to dispatch unknown opcode 0 for wl_shm, aborting.

