### PR TITLE
Add labels for some error messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ vulkan-portability = ["wgc/gfx-backend-vulkan", "gfx-backend-vulkan"]
 package = "wgpu-core"
 #version = "0.6"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "19b4ec58ae4fb065dcbcf4825f5852b0d10520d0"
+rev = "9d35aea08eb5cdd5ad408e8a13838a7beab11ad3"
 features = ["raw-window-handle"]
 
 [dependencies.wgt]
 package = "wgpu-types"
 #version = "0.6"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "19b4ec58ae4fb065dcbcf4825f5852b0d10520d0"
+rev = "9d35aea08eb5cdd5ad408e8a13838a7beab11ad3"
 
 [dependencies]
 arrayvec = "0.5"

--- a/src/backend/error.rs
+++ b/src/backend/error.rs
@@ -1,0 +1,238 @@
+use std::{error::Error, fmt::Display};
+
+use super::Context;
+
+pub(crate) fn format_error(err: &(impl Error + 'static), context: &Context) -> String {
+    let mut err_descs = Vec::new();
+
+    err_descs.push(fmt_pretty_any(err, context));
+
+    let mut source_opt = err.source();
+    while let Some(source) = source_opt {
+        err_descs.push(fmt_pretty_any(source, context));
+        source_opt = source.source();
+    }
+
+    let desc = format!("Validation Error\n\nCaused by:\n{}", err_descs.join(""));
+    desc
+}
+
+fn fmt_pretty_any(error: &(dyn Error + 'static), context: &Context) -> String {
+    if let Some(pretty_err) = error.downcast_ref::<super::direct::ContextError>() {
+        return pretty_err.fmt_pretty(context);
+    }
+    if let Some(pretty_err) = error.downcast_ref::<wgc::command::RenderCommandError>() {
+        return pretty_err.fmt_pretty(context);
+    }
+    if let Some(pretty_err) = error.downcast_ref::<wgc::binding_model::CreateBindGroupError>() {
+        return pretty_err.fmt_pretty(context);
+    }
+    if let Some(pretty_err) = error.downcast_ref::<wgc::binding_model::CreatePipelineLayoutError>()
+    {
+        return pretty_err.fmt_pretty(context);
+    }
+    if let Some(pretty_err) = error.downcast_ref::<wgc::command::ExecutionError>() {
+        return pretty_err.fmt_pretty(context);
+    }
+    if let Some(pretty_err) = error.downcast_ref::<wgc::command::RenderPassErrorInner>() {
+        return pretty_err.fmt_pretty(context);
+    }
+    if let Some(pretty_err) = error.downcast_ref::<wgc::command::ComputePassErrorInner>() {
+        return pretty_err.fmt_pretty(context);
+    }
+    if let Some(pretty_err) = error.downcast_ref::<wgc::command::TransferError>() {
+        return pretty_err.fmt_pretty(context);
+    }
+
+    // default
+    format_error_line(error.as_display())
+}
+
+pub(crate) fn format_error_line(err: &dyn Display) -> String {
+    format!("    {}\n", err)
+}
+
+pub(crate) fn format_note_line(note: &dyn Display) -> String {
+    format!("      note: {}\n", note)
+}
+
+pub(crate) fn format_label_line(label_key: &str, label_value: &str) -> String {
+    if label_key.is_empty() || label_value.is_empty() {
+        String::new()
+    } else {
+        format_note_line(&format!("{} = `{}`", label_key, label_value))
+    }
+}
+
+trait AsDisplay {
+    fn as_display(&self) -> &dyn Display;
+}
+
+impl<T: Display> AsDisplay for T {
+    fn as_display(&self) -> &dyn Display {
+        self
+    }
+}
+
+pub trait PrettyError: Error {
+    fn fmt_pretty(&self, _context: &Context) -> String {
+        format_error_line(self.as_display())
+    }
+}
+
+impl PrettyError for super::direct::ContextError {
+    fn fmt_pretty(&self, _context: &Context) -> String {
+        format_error_line(self.as_display()) + &format_label_line("label", &self.label)
+    }
+}
+
+impl PrettyError for wgc::command::RenderCommandError {
+    fn fmt_pretty(&self, context: &Context) -> String {
+        let global = context.global();
+        let mut ret = format_error_line(self);
+        match *self {
+            Self::InvalidBindGroup(id) => {
+                let name = wgc::gfx_select!(id => global.bind_group_label(id));
+                ret.push_str(&format_label_line("bind group", &name));
+            }
+            Self::InvalidPipeline(id) => {
+                let name = wgc::gfx_select!(id => global.render_pipeline_label(id));
+                ret.push_str(&format_label_line("render pipeline", &name));
+            }
+            Self::Buffer(id, ..) | Self::DestroyedBuffer(id) => {
+                let name = wgc::gfx_select!(id => global.buffer_label(id));
+                ret.push_str(&format_label_line("buffer", &name));
+            }
+            _ => {}
+        };
+        ret
+    }
+}
+impl PrettyError for wgc::binding_model::CreateBindGroupError {
+    fn fmt_pretty(&self, context: &Context) -> String {
+        let global = context.global();
+        let mut ret = format_error_line(self);
+        match *self {
+            Self::InvalidBuffer(id) => {
+                let name = wgc::gfx_select!(id => global.buffer_label(id));
+                ret.push_str(&format_label_line("buffer", &name));
+            }
+            Self::InvalidTextureView(id) => {
+                let name = wgc::gfx_select!(id => global.texture_view_label(id));
+                ret.push_str(&format_label_line("texture view", &name));
+            }
+            Self::InvalidSampler(id) => {
+                let name = wgc::gfx_select!(id => global.sampler_label(id));
+                ret.push_str(&format_label_line("sampler", &name));
+            }
+            _ => {}
+        };
+        ret
+    }
+}
+
+impl PrettyError for wgc::binding_model::CreatePipelineLayoutError {
+    fn fmt_pretty(&self, context: &Context) -> String {
+        let global = context.global();
+        let mut ret = format_error_line(self);
+        match *self {
+            Self::InvalidBindGroupLayout(id) => {
+                let name = wgc::gfx_select!(id => global.bind_group_layout_label(id));
+                ret.push_str(&format_label_line("bind group layout", &name));
+            }
+            _ => {}
+        };
+        ret
+    }
+}
+
+impl PrettyError for wgc::command::ExecutionError {
+    fn fmt_pretty(&self, context: &Context) -> String {
+        let global = context.global();
+        let mut ret = format_error_line(self);
+        match *self {
+            Self::DestroyedBuffer(id) => {
+                let name = wgc::gfx_select!(id => global.buffer_label(id));
+                ret.push_str(&format_label_line("buffer", &name));
+            }
+        };
+        ret
+    }
+}
+
+impl PrettyError for wgc::command::RenderPassErrorInner {
+    fn fmt_pretty(&self, context: &Context) -> String {
+        let global = context.global();
+        let mut ret = format_error_line(self);
+        match *self {
+            Self::InvalidAttachment(id) => {
+                let name = wgc::gfx_select!(id => global.texture_view_label(id));
+                ret.push_str(&format_label_line("attachment", &name));
+            }
+            _ => {}
+        };
+        ret
+    }
+}
+
+impl PrettyError for wgc::command::ComputePassErrorInner {
+    fn fmt_pretty(&self, context: &Context) -> String {
+        let global = context.global();
+        let mut ret = format_error_line(self);
+        match *self {
+            Self::InvalidBindGroup(id) => {
+                let name = wgc::gfx_select!(id => global.bind_group_label(id));
+                ret.push_str(&format_label_line("bind group", &name));
+            }
+            Self::InvalidPipeline(id) => {
+                let name = wgc::gfx_select!(id => global.compute_pipeline_label(id));
+                ret.push_str(&format_label_line("pipeline", &name));
+            }
+            Self::InvalidIndirectBuffer(id) => {
+                let name = wgc::gfx_select!(id => global.buffer_label(id));
+                ret.push_str(&format_label_line("indirect buffer", &name));
+            }
+            _ => {}
+        };
+        ret
+    }
+}
+
+impl PrettyError for wgc::command::TransferError {
+    fn fmt_pretty(&self, context: &Context) -> String {
+        let global = context.global();
+        let mut ret = format_error_line(self);
+        match *self {
+            Self::InvalidBuffer(id) => {
+                let name = wgc::gfx_select!(id => global.buffer_label(id));
+                ret.push_str(&format_label_line("label", &name));
+            }
+            Self::InvalidTexture(id) => {
+                let name = wgc::gfx_select!(id => global.texture_label(id));
+                ret.push_str(&format_label_line("texture", &name));
+            }
+            // Self::MissingCopySrcUsageFlag(buf_opt, tex_opt) => {
+            //     if let Some(buf) = buf_opt {
+            //         let name = wgc::gfx_select!(buf => global.buffer_label(buf));
+            //         ret.push_str(&format_label_line("source", &name));
+            //     }
+            //     if let Some(tex) = tex_opt {
+            //         let name = wgc::gfx_select!(tex => global.texture_label(tex));
+            //         ret.push_str(&format_label_line("source", &name));
+            //     }
+            // }
+            Self::MissingCopyDstUsageFlag(buf_opt, tex_opt) => {
+                if let Some(buf) = buf_opt {
+                    let name = wgc::gfx_select!(buf => global.buffer_label(buf));
+                    ret.push_str(&format_label_line("destination", &name));
+                }
+                if let Some(tex) = tex_opt {
+                    let name = wgc::gfx_select!(tex => global.texture_label(tex));
+                    ret.push_str(&format_label_line("destination", &name));
+                }
+            }
+            _ => {}
+        };
+        ret
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -5,6 +5,8 @@ pub(crate) use web::Context;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod direct;
+#[cfg(not(target_arch = "wasm32"))]
+mod error;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) use direct::Context;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2696,6 +2696,8 @@ pub enum Error {
     ValidationError {
         ///
         source: Box<dyn error::Error + Send + Sync + 'static>,
+        ///
+        description: String,
     },
 }
 
@@ -2703,7 +2705,7 @@ impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             Error::OutOfMemoryError { source } => Some(source.as_ref()),
-            Error::ValidationError { source } => Some(source.as_ref()),
+            Error::ValidationError { source, .. } => Some(source.as_ref()),
         }
     }
 }
@@ -2712,7 +2714,7 @@ impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::OutOfMemoryError { .. } => f.write_str("Out of Memory"),
-            Error::ValidationError { .. } => f.write_str("Validation error"),
+            Error::ValidationError { description, .. } => f.write_str(description),
         }
     }
 }


### PR DESCRIPTION
This places some pieces on how to transform the ids in the errors to a label, and adds them to the validation message.

This changes the formatting of the validation error to happen when constructing the error, rather than in the unhandled error handler.
It also requires some code for all the error variants for extracting the ids.