### PR TITLE
Removed unusued Uniform struct in texture-arrays example.

### DIFF
--- a/examples/texture-arrays/main.rs
+++ b/examples/texture-arrays/main.rs
@@ -13,12 +13,6 @@ struct Vertex {
     _index: u32,
 }
 
-#[repr(C)]
-#[derive(Clone, Copy, Pod, Zeroable)]
-struct Uniform {
-    index: u32,
-}
-
 fn vertex(pos: [i8; 2], tc: [i8; 2], index: i8) -> Vertex {
     Vertex {
         _pos: [pos[0] as f32, pos[1] as f32],


### PR DESCRIPTION
The Uniform struct in the texture-arrays example is unused.