### PR TITLE
Remove implicit conversion hello-triangle shader.vert

### DIFF
--- a/examples/hello-triangle/shader.vert
+++ b/examples/hello-triangle/shader.vert
@@ -5,6 +5,7 @@ out gl_PerVertex {
 };
 
 void main() {
-    vec2 position = vec2(gl_VertexIndex, (gl_VertexIndex & 1) * 2) - 1;
-    gl_Position = vec4(position, 0.0, 1.0);
+    float x = float(gl_VertexIndex - 1);
+    float y = float(((gl_VertexIndex & 1) * 2) - 1);
+    gl_Position = vec4(x, y, 0.0, 1.0);
 }


### PR DESCRIPTION
Remove implicit conversion to float, and change it to explicit conversion. Reason for this change is to prepare the hello-triangle example for Naga glsl-spirv path.