### PR TITLE
Temporarily use `BackendBit::PRIMARY` in examples

### DIFF
--- a/examples/hello-compute/main.rs
+++ b/examples/hello-compute/main.rs
@@ -21,7 +21,7 @@ async fn run() {
 
 async fn execute_gpu(numbers: Vec<u32>) -> Vec<u32> {
     // Instantiates instance of WebGPU
-    let instance = wgpu::Instance::new(wgpu::BackendBit::all());
+    let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
 
     // `request_adapter` instantiates the general connection to the GPU
     let adapter = instance

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -6,7 +6,7 @@ use winit::{
 
 async fn run(event_loop: EventLoop<()>, window: Window, swapchain_format: wgpu::TextureFormat) {
     let size = window.inner_size();
-    let instance = wgpu::Instance::new(wgpu::BackendBit::all());
+    let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
     let surface = unsafe { instance.create_surface(&window) };
     let adapter = instance
         .request_adapter(&wgpu::RequestAdapterOptions {

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -15,7 +15,7 @@ async fn run(event_loop: EventLoop<()>, window: Window, swapchain_format: wgpu::
             compatible_surface: Some(&surface),
         })
         .await
-        .expect("Failed to find an appropiate adapter");
+        .expect("Failed to find an appropriate adapter");
 
     // Create the logical device and command queue
     let (device, queue) = adapter

--- a/examples/hello-windows/main.rs
+++ b/examples/hello-windows/main.rs
@@ -79,7 +79,7 @@ async fn run(
             compatible_surface: viewports.first().map(|desc| &desc.surface),
         })
         .await
-        .expect("Failed to find an appropiate adapter");
+        .expect("Failed to find an appropriate adapter");
 
     // Create the logical device and command queue
     let (device, queue) = adapter

--- a/examples/hello-windows/main.rs
+++ b/examples/hello-windows/main.rs
@@ -67,7 +67,7 @@ async fn run(
     viewports: Vec<(Window, wgpu::Color)>,
     swapchain_format: wgpu::TextureFormat,
 ) {
-    let instance = wgpu::Instance::new(wgpu::BackendBit::all());
+    let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
     let viewports: Vec<_> = viewports
         .into_iter()
         .map(|(window, color)| ViewportDesc::new(window, color, &instance))

--- a/examples/hello/main.rs
+++ b/examples/hello/main.rs
@@ -1,7 +1,7 @@
 /// This example shows how to describe the adapter in use.
 async fn run() {
     #[cfg_attr(target_arch = "wasm32", allow(unused_variables))]
-    let adapter = wgpu::Instance::new(wgpu::BackendBit::all())
+    let adapter = wgpu::Instance::new(wgpu::BackendBit::PRIMARY)
         .request_adapter(&wgpu::RequestAdapterOptions::default())
         .await
         .unwrap();


### PR DESCRIPTION
`BackendBit::all()` allows GL/surfman to be used on macOS which appears to prevent rendering with Metal (e.g. hello-triangle displays an empty window).

surfman will be removed in later versions of gfx, which will allow us to switch back to `BackendBit::all()` in the examples.