### PR TITLE
Port to the updated wgpu error model

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ vulkan-portability = ["wgc/gfx-backend-vulkan", "gfx-backend-vulkan"]
 package = "wgpu-core"
 #version = "0.6"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "feac96d3151f08188bdd270fdf021117944c01b0"
+rev = "385ee9fecfbe185b63d788b4007f131a6ef34cf0"
 features = ["raw-window-handle"]
 
 [dependencies.wgt]
 package = "wgpu-types"
 #version = "0.6"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "feac96d3151f08188bdd270fdf021117944c01b0"
+rev = "385ee9fecfbe185b63d788b4007f131a6ef34cf0"
 
 [dependencies]
 arrayvec = "0.5"

--- a/examples/capture/main.rs
+++ b/examples/capture/main.rs
@@ -36,6 +36,7 @@ async fn create_red_image_with_dimensions(
     let (device, queue) = adapter
         .request_device(
             &wgpu::DeviceDescriptor {
+                label: None,
                 features: wgpu::Features::empty(),
                 limits: wgpu::Limits::default(),
                 shader_validation: true,

--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -149,6 +149,7 @@ async fn setup<E: Example>(title: &str) -> Setup {
     let (device, queue) = adapter
         .request_device(
             &wgpu::DeviceDescriptor {
+                label: None,
                 features: (optional_features & adapter_features) | required_features,
                 limits: needed_limits,
                 shader_validation: true,

--- a/examples/hello-compute/main.rs
+++ b/examples/hello-compute/main.rs
@@ -34,6 +34,7 @@ async fn execute_gpu(numbers: Vec<u32>) -> Vec<u32> {
     let (device, queue) = adapter
         .request_device(
             &wgpu::DeviceDescriptor {
+                label: None,
                 features: wgpu::Features::empty(),
                 limits: wgpu::Limits::default(),
                 shader_validation: true,

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -21,6 +21,7 @@ async fn run(event_loop: EventLoop<()>, window: Window, swapchain_format: wgpu::
     let (device, queue) = adapter
         .request_device(
             &wgpu::DeviceDescriptor {
+                label: None,
                 features: wgpu::Features::empty(),
                 limits: wgpu::Limits::default(),
                 shader_validation: true,

--- a/examples/hello-windows/main.rs
+++ b/examples/hello-windows/main.rs
@@ -85,6 +85,7 @@ async fn run(
     let (device, queue) = adapter
         .request_device(
             &wgpu::DeviceDescriptor {
+                label: None,
                 features: wgpu::Features::empty(),
                 limits: wgpu::Limits::default(),
                 shader_validation: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,10 @@ pub use wgt::{
     AddressMode, Backend, BackendBit, BindGroupLayoutEntry, BindingType, BlendDescriptor,
     BlendFactor, BlendOperation, BufferAddress, BufferSize, BufferUsage, Color,
     ColorStateDescriptor, ColorWrite, CommandBufferDescriptor, CompareFunction, CullMode,
-    DepthStencilStateDescriptor, DeviceDescriptor, DynamicOffset, Extent3d, Features, FilterMode,
-    FrontFace, IndexFormat, InputStepMode, Limits, Origin3d, PolygonMode, PowerPreference,
-    PresentMode, PrimitiveTopology, PushConstantRange, RasterizationStateDescriptor,
-    SamplerBorderColor, ShaderLocation, ShaderStage, StencilOperation, StencilStateDescriptor,
+    DepthStencilStateDescriptor, DynamicOffset, Extent3d, Features, FilterMode, FrontFace,
+    IndexFormat, InputStepMode, Limits, Origin3d, PolygonMode, PowerPreference, PresentMode,
+    PrimitiveTopology, PushConstantRange, RasterizationStateDescriptor, SamplerBorderColor,
+    ShaderLocation, ShaderStage, StencilOperation, StencilStateDescriptor,
     StencilStateFaceDescriptor, SwapChainDescriptor, SwapChainStatus, TextureAspect,
     TextureComponentType, TextureDataLayout, TextureDimension, TextureFormat, TextureUsage,
     TextureViewDimension, VertexAttributeDescriptor, VertexFormat, BIND_BUFFER_ALIGNMENT,
@@ -969,58 +969,21 @@ pub struct RenderPassDepthStencilAttachmentDescriptor<'a> {
 
 // The underlying types are also exported so that documentation shows up for them
 
+/// Object label.
+pub type Label<'a> = Option<&'a str>;
 pub use wgt::RequestAdapterOptions as RequestAdapterOptionsBase;
 /// Additional information required when requesting an adapter.
 pub type RequestAdapterOptions<'a> = RequestAdapterOptionsBase<&'a Surface>;
-
+/// Describes a [`Device`].
+pub type DeviceDescriptor<'a> = wgt::DeviceDescriptor<Label<'a>>;
 /// Describes a [`Buffer`].
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct BufferDescriptor<'a> {
-    /// Debug label of a buffer. This will show up in graphics debuggers for easy identification.
-    pub label: Option<&'a str>,
-    /// Size of a buffer.
-    pub size: BufferAddress,
-    /// Usages of a buffer. If the buffer is used in any way that isn't specified here, the operation
-    /// will panic.
-    pub usage: BufferUsage,
-    /// Allows a buffer to be mapped immediately after they are made. It does not have to be [`BufferUsage::MAP_READ`] or
-    /// [`BufferUsage::MAP_WRITE`], all buffers are allowed to be mapped at creation.
-    pub mapped_at_creation: bool,
-}
-
+pub type BufferDescriptor<'a> = wgt::BufferDescriptor<Label<'a>>;
 /// Describes a [`CommandEncoder`].
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
-pub struct CommandEncoderDescriptor<'a> {
-    /// Debug label for the command encoder. This will show up in graphics debuggers for easy identification.
-    pub label: Option<&'a str>,
-}
-
+pub type CommandEncoderDescriptor<'a> = wgt::CommandEncoderDescriptor<Label<'a>>;
 /// Describes a [`RenderBundle`].
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
-pub struct RenderBundleDescriptor<'a> {
-    /// Debug label of the render bundle encoder. This will show up in graphics debuggers for easy identification.
-    pub label: Option<&'a str>,
-}
-
+pub type RenderBundleDescriptor<'a> = wgt::RenderBundleDescriptor<Label<'a>>;
 /// Describes a [`Texture`].
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct TextureDescriptor<'a> {
-    /// Debug label of the texture. This will show up in graphics debuggers for easy identification.
-    pub label: Option<&'a str>,
-    /// Size of the texture. For a regular 1D/2D texture, the unused sizes will be 1. For 2DArray textures, Z is the
-    /// number of 2D textures in that array.
-    pub size: Extent3d,
-    /// Mip count of texture. For a texture with no extra mips, this must be 1.
-    pub mip_level_count: u32,
-    /// Sample count of texture. If this is not 1, texture must have [`BindingType::SampledTexture::multisampled`] set to true.
-    pub sample_count: u32,
-    /// Dimensions of the texture.
-    pub dimension: TextureDimension,
-    /// Format of the texture.
-    pub format: TextureFormat,
-    /// Allowed usages of the texture. If used in other ways, the operation will panic.
-    pub usage: TextureUsage,
-}
+pub type TextureDescriptor<'a> = wgt::TextureDescriptor<Label<'a>>;
 
 /// Describes a [`TextureView`].
 #[derive(Clone, Debug, Default, PartialEq)]


### PR DESCRIPTION
Depends on https://github.com/gfx-rs/wgpu/pull/1034

I removed most of the helping sugar we had before, in exchange for simple `match` and a `handle_error` function.
I believe this way it's easier to maintain and debug (stepping through closures is a pain today).