### PR TITLE
Make BindingResource::TextureViewArray more flexible (addresses #588)

### DIFF
--- a/examples/texture-arrays/main.rs
+++ b/examples/texture-arrays/main.rs
@@ -218,8 +218,8 @@ impl framework::Example for Example {
                 wgpu::BindGroupEntry {
                     binding: 0,
                     resource: wgpu::BindingResource::TextureViewArray(&[
-                        red_texture_view,
-                        green_texture_view,
+                        &red_texture_view,
+                        &green_texture_view,
                     ]),
                 },
                 wgpu::BindGroupEntry {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -895,7 +895,7 @@ pub enum BindingResource<'a> {
     ///
     /// Corresponds to [`BindingType::SampledTexture`] and [`BindingType::StorageTexture`] with
     /// [`BindGroupLayoutEntry::count`] set to Some.
-    TextureViewArray(&'a [TextureView]),
+    TextureViewArray(&'a [&'a TextureView]),
 }
 
 /// Operation to perform to the output attachment at the start of a renderpass.


### PR DESCRIPTION
Fixes #588 

Rather than having a field of `&[TextureView]`, which requires either keeping all TextureViews in a vector in the first place or moving them into a temporary vector or array and back, use `&[&TextureView]` instead. Obviates the need for hacky workarounds if you keep your TextureViews in non-contiguous structs, maps, or can't move them, etc.

For those using a vector previously, the required transformation is merely `.iter().collect()`.