### PR TITLE
Removing gfx-backend-gl on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ vulkan-portability = ["wgc/gfx-backend-vulkan", "gfx-backend-vulkan"]
 package = "wgpu-core"
 #version = "0.6"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "fd99466867a5d1dd03f543be89cda2958dddedb8"
+rev = "3efba7712abdd75a6b3b35c03969a59e9ac92032"
 features = ["raw-window-handle"]
 
 [dependencies.wgt]
 package = "wgpu-types"
 #version = "0.6"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "fd99466867a5d1dd03f543be89cda2958dddedb8"
+rev = "3efba7712abdd75a6b3b35c03969a59e9ac92032"
 
 [dependencies]
 arrayvec = "0.5"
@@ -50,7 +50,6 @@ serde = { version = "1", features = ["derive"], optional = true }
 # want to opt into X11 explicitly.
 [target.'cfg(all(unix, not(target_os = "ios"), not(target_os = "macos")))'.dependencies]
 gfx-backend-vulkan = { version = "0.6", features = ["x11"] }
-[target.'cfg(unix)'.dependencies]
 gfx-backend-gl = { version = "0.6", features = ["x11"] }
 
 [dev-dependencies]

--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -66,7 +66,6 @@ impl Context {
                 .metal
                 .as_ref()
                 .map(|inst| inst.create_surface_from_layer(std::mem::transmute(layer))),
-            gl: None,
         };
 
         let id = self.0.surfaces.process_id(PhantomData);


### PR DESCRIPTION
Updating to latest wgpu.
Removing references to gfx-backend-gl on macOS.

Fixes https://github.com/gfx-rs/wgpu-rs/issues/646