### PR TITLE
Use web-sys release instead of patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,18 +96,14 @@ test = true
 #gfx-backend-dx12 = { version = "0.6", path = "../gfx/src/backend/dx12" }
 #gfx-backend-dx11 = { version = "0.6", path = "../gfx/src/backend/dx11" }
 #gfx-backend-metal = { version = "0.6", path = "../gfx/src/backend/metal" }
-wasm-bindgen = { git = "https://github.com/rustwasm/wasm-bindgen", rev = "316c5a70fdc4a052fb65ef82bf02d52107b5671b" }
-wasm-bindgen-futures = { git = "https://github.com/rustwasm/wasm-bindgen", rev = "316c5a70fdc4a052fb65ef82bf02d52107b5671b" }
-web-sys = { git = "https://github.com/rustwasm/wasm-bindgen", rev = "316c5a70fdc4a052fb65ef82bf02d52107b5671b" }
-js-sys = { git = "https://github.com/rustwasm/wasm-bindgen", rev = "316c5a70fdc4a052fb65ef82bf02d52107b5671b" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2.7"
 gfx-backend-vulkan = { version = "0.6", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "=0.2.68" # remember to change version in readme as well
-web-sys = { version = "=0.3.45", features = [
+wasm-bindgen = "=0.2.69" # remember to change version in readme as well
+web-sys = { version = "=0.3.46", features = [
     "Document",
     "Navigator",
     "Node",
@@ -200,8 +196,8 @@ web-sys = { version = "=0.3.45", features = [
     "HtmlCanvasElement",
     "Window",
 ]}
-js-sys = "0.3.45"
-wasm-bindgen-futures = "0.4.18"
+js-sys = "0.3.46"
+wasm-bindgen-futures = "0.4.19"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 console_error_panic_hook = "0.1.6"

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To run examples on the `wasm32-unknown-unknown` target, first build the example 
 # Checkout `gecko` branch that matches the state of Firefox
 git checkout upstream/gecko
 # Install or update wasm-bindgen-cli
-cargo install -f wasm-bindgen-cli --version 0.2.68
+cargo install -f wasm-bindgen-cli --version 0.2.69
 # Build with the wasm target
 RUSTFLAGS=--cfg=web_sys_unstable_apis cargo build --target wasm32-unknown-unknown --example hello-triangle
 # Generate bindings in a `target/generated` directory


### PR DESCRIPTION
`patch` isn't necessary anymore because there's a new release of web-sys and wasm-bindgen

Fixes #637