### PR TITLE
Publish examples to subdirectory

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,4 +44,4 @@ jobs:
           FOLDER: target/generated
           REPOSITORY_NAME: gfx-rs/wgpu-rs.github.io
           BRANCH: master
-          TARGET_FOLDER: examples
+          TARGET_FOLDER: examples/wasm


### PR DESCRIPTION
Avoid removing existing directory contents by publishing wasm examples to a subdirectory instead.