### PR TITLE
Add EGL to docs action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,11 @@ jobs:
           override: true
         continue-on-error: true
 
+      - name: Add EGL for OpenGL
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq libegl1-mesa-dev
+
       - name: Build the docs (nightly)
         run: |
           cargo +nightly doc --lib --all-features


### PR DESCRIPTION
Looks like we need to install EGL for the docs action to match the regular CI action, see https://github.com/gfx-rs/wgpu-rs/runs/1478040907