### PR TITLE
API and examples update for index_format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ vulkan-portability = ["wgc/gfx-backend-vulkan"]
 package = "wgpu-core"
 #version = "0.6"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "2d87fd9067e6600beea494f83aa27955b0c8e100"
+rev = "4513fb2b83fe2cd19682ccca9c55a6995f061699"
 features = ["raw-window-handle"]
 
 [dependencies.wgt]
 package = "wgpu-types"
 #version = "0.6"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "2d87fd9067e6600beea494f83aa27955b0c8e100"
+rev = "4513fb2b83fe2cd19682ccca9c55a6995f061699"
 
 [dependencies]
 arrayvec = "0.5"

--- a/examples/boids/main.rs
+++ b/examples/boids/main.rs
@@ -132,7 +132,7 @@ impl framework::Example for Example {
             color_states: &[sc_desc.format.into()],
             depth_stencil_state: None,
             vertex_state: wgpu::VertexStateDescriptor {
-                index_format: wgpu::IndexFormat::Uint16,
+                index_format: None,
                 vertex_buffers: &[
                     wgpu::VertexBufferDescriptor {
                         stride: 4 * 4,

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -90,6 +90,7 @@ fn create_texels(size: usize) -> Vec<u8> {
 struct Example {
     vertex_buf: wgpu::Buffer,
     index_buf: wgpu::Buffer,
+    index_format: wgpu::IndexFormat,
     index_count: usize,
     bind_group: wgpu::BindGroup,
     uniform_buf: wgpu::Buffer,
@@ -250,9 +251,10 @@ impl framework::Example for Example {
             label: None,
         });
 
+        let index_format = wgpu::IndexFormat::Uint16;
         // Create the render pipeline
         let vertex_state = wgpu::VertexStateDescriptor {
-            index_format: wgpu::IndexFormat::Uint16,
+            index_format: Some(index_format),
             vertex_buffers: &[wgpu::VertexBufferDescriptor {
                 stride: vertex_size as wgpu::BufferAddress,
                 step_mode: wgpu::InputStepMode::Vertex,
@@ -352,6 +354,7 @@ impl framework::Example for Example {
         Example {
             vertex_buf,
             index_buf,
+            index_format,
             index_count: index_data.len(),
             bind_group,
             uniform_buf,
@@ -404,7 +407,7 @@ impl framework::Example for Example {
             rpass.push_debug_group("Prepare data for draw.");
             rpass.set_pipeline(&self.pipeline);
             rpass.set_bind_group(0, &self.bind_group, &[]);
-            rpass.set_index_buffer(self.index_buf.slice(..));
+            rpass.set_index_buffer(self.index_buf.slice(..), self.index_format);
             rpass.set_vertex_buffer(0, self.vertex_buf.slice(..));
             rpass.pop_debug_group();
             rpass.insert_debug_marker("Draw!");

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -58,7 +58,7 @@ async fn run(event_loop: EventLoop<()>, window: Window, swapchain_format: wgpu::
         color_states: &[swapchain_format.into()],
         depth_stencil_state: None,
         vertex_state: wgpu::VertexStateDescriptor {
-            index_format: wgpu::IndexFormat::Uint16,
+            index_format: None,
             vertex_buffers: &[],
         },
         sample_count: 1,

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -102,7 +102,7 @@ impl Example {
             color_states: &[TEXTURE_FORMAT.into()],
             depth_stencil_state: None,
             vertex_state: wgpu::VertexStateDescriptor {
-                index_format: wgpu::IndexFormat::Uint16,
+                index_format: None,
                 vertex_buffers: &[],
             },
             sample_count: 1,
@@ -280,7 +280,7 @@ impl framework::Example for Example {
             color_states: &[sc_desc.format.into()],
             depth_stencil_state: None,
             vertex_state: wgpu::VertexStateDescriptor {
-                index_format: wgpu::IndexFormat::Uint16,
+                index_format: None,
                 vertex_buffers: &[wgpu::VertexBufferDescriptor {
                     stride: vertex_size as wgpu::BufferAddress,
                     step_mode: wgpu::InputStepMode::Vertex,

--- a/examples/msaa-line/main.rs
+++ b/examples/msaa-line/main.rs
@@ -67,7 +67,7 @@ impl Example {
             color_states: &[sc_desc.format.into()],
             depth_stencil_state: None,
             vertex_state: wgpu::VertexStateDescriptor {
-                index_format: wgpu::IndexFormat::Uint16,
+                index_format: None,
                 vertex_buffers: &[wgpu::VertexBufferDescriptor {
                     stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::InputStepMode::Vertex,

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -85,6 +85,7 @@ struct Entity {
     color: wgpu::Color,
     vertex_buf: Rc<wgpu::Buffer>,
     index_buf: Rc<wgpu::Buffer>,
+    index_format: wgpu::IndexFormat,
     index_count: usize,
     uniform_offset: wgpu::DynamicOffset,
 }
@@ -277,6 +278,8 @@ impl framework::Example for Example {
             mapped_at_creation: false,
         });
 
+        let index_format = wgpu::IndexFormat::Uint16;
+
         let mut entities = vec![{
             use cgmath::SquareMatrix;
             Entity {
@@ -285,6 +288,7 @@ impl framework::Example for Example {
                 color: wgpu::Color::WHITE,
                 vertex_buf: Rc::new(plane_vertex_buf),
                 index_buf: Rc::new(plane_index_buf),
+                index_format,
                 index_count: plane_index_data.len(),
                 uniform_offset: 0,
             }
@@ -304,6 +308,7 @@ impl framework::Example for Example {
                 color: wgpu::Color::GREEN,
                 vertex_buf: Rc::clone(&cube_vertex_buf),
                 index_buf: Rc::clone(&cube_index_buf),
+                index_format,
                 index_count: cube_index_data.len(),
                 uniform_offset: ((i + 1) * wgpu::BIND_BUFFER_ALIGNMENT as usize) as _,
             });
@@ -487,7 +492,7 @@ impl framework::Example for Example {
                     stencil: wgpu::StencilStateDescriptor::default(),
                 }),
                 vertex_state: wgpu::VertexStateDescriptor {
-                    index_format: wgpu::IndexFormat::Uint16,
+                    index_format: Some(index_format),
                     vertex_buffers: &[vb_desc.clone()],
                 },
                 sample_count: 1,
@@ -623,7 +628,7 @@ impl framework::Example for Example {
                     stencil: wgpu::StencilStateDescriptor::default(),
                 }),
                 vertex_state: wgpu::VertexStateDescriptor {
-                    index_format: wgpu::IndexFormat::Uint16,
+                    index_format: Some(index_format),
                     vertex_buffers: &[vb_desc],
                 },
                 sample_count: 1,
@@ -780,7 +785,7 @@ impl framework::Example for Example {
 
                 for entity in &self.entities {
                     pass.set_bind_group(1, &self.entity_bind_group, &[entity.uniform_offset]);
-                    pass.set_index_buffer(entity.index_buf.slice(..));
+                    pass.set_index_buffer(entity.index_buf.slice(..), entity.index_format);
                     pass.set_vertex_buffer(0, entity.vertex_buf.slice(..));
                     pass.draw_indexed(0..entity.index_count as u32, 0, 0..1);
                 }
@@ -821,7 +826,7 @@ impl framework::Example for Example {
 
             for entity in &self.entities {
                 pass.set_bind_group(1, &self.entity_bind_group, &[entity.uniform_offset]);
-                pass.set_index_buffer(entity.index_buf.slice(..));
+                pass.set_index_buffer(entity.index_buf.slice(..), entity.index_format);
                 pass.set_vertex_buffer(0, entity.vertex_buf.slice(..));
                 pass.draw_indexed(0..entity.index_count as u32, 0, 0..1);
             }

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -121,7 +121,7 @@ impl framework::Example for Skybox {
             primitive_topology: wgpu::PrimitiveTopology::TriangleList,
             color_states: &[sc_desc.format.into()],
             vertex_state: wgpu::VertexStateDescriptor {
-                index_format: wgpu::IndexFormat::Uint16,
+                index_format: None,
                 vertex_buffers: &[],
             },
             depth_stencil_state: None,

--- a/examples/texture-arrays/main.rs
+++ b/examples/texture-arrays/main.rs
@@ -65,6 +65,7 @@ struct Example {
     bind_group: wgpu::BindGroup,
     vertex_buffer: wgpu::Buffer,
     index_buffer: wgpu::Buffer,
+    index_format: wgpu::IndexFormat,
     uniform_workaround: bool,
 }
 
@@ -247,6 +248,8 @@ impl framework::Example for Example {
             },
         });
 
+        let index_format = wgpu::IndexFormat::Uint16;
+
         let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: None,
             layout: Some(&pipeline_layout),
@@ -267,7 +270,7 @@ impl framework::Example for Example {
             color_states: &[sc_desc.format.into()],
             depth_stencil_state: None,
             vertex_state: wgpu::VertexStateDescriptor {
-                index_format: wgpu::IndexFormat::Uint16,
+                index_format: Some(index_format),
                 vertex_buffers: &[wgpu::VertexBufferDescriptor {
                     stride: vertex_size as wgpu::BufferAddress,
                     step_mode: wgpu::InputStepMode::Vertex,
@@ -282,6 +285,7 @@ impl framework::Example for Example {
         Self {
             vertex_buffer,
             index_buffer,
+            index_format,
             bind_group,
             pipeline,
             uniform_workaround,
@@ -324,7 +328,7 @@ impl framework::Example for Example {
         rpass.set_pipeline(&self.pipeline);
         rpass.set_bind_group(0, &self.bind_group, &[]);
         rpass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
-        rpass.set_index_buffer(self.index_buffer.slice(..));
+        rpass.set_index_buffer(self.index_buffer.slice(..), self.index_format);
         if self.uniform_workaround {
             rpass.set_push_constants(wgpu::ShaderStage::FRAGMENT, 0, bytemuck::cast_slice(&[0]));
             rpass.draw_indexed(0..6, 0, 0..1);

--- a/examples/water/main.rs
+++ b/examples/water/main.rs
@@ -557,7 +557,7 @@ impl framework::Example for Example {
                 // We don't actually use indices, since it's unnecessary
                 // because we duplicate all the data anyway. This is
                 // necessary to achieve the low-poly effect.
-                index_format: wgpu::IndexFormat::Uint16,
+                index_format: None,
                 vertex_buffers: &[wgpu::VertexBufferDescriptor {
                     stride: water_vertex_size as wgpu::BufferAddress,
                     step_mode: wgpu::InputStepMode::Vertex,
@@ -595,7 +595,7 @@ impl framework::Example for Example {
                 stencil: wgpu::StencilStateDescriptor::default(),
             }),
             vertex_state: wgpu::VertexStateDescriptor {
-                index_format: wgpu::IndexFormat::Uint16,
+                index_format: None,
                 vertex_buffers: &[wgpu::VertexBufferDescriptor {
                     stride: terrain_vertex_size as wgpu::BufferAddress,
                     step_mode: wgpu::InputStepMode::Vertex,

--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -221,10 +221,11 @@ mod pass_impl {
         fn set_index_buffer(
             &mut self,
             buffer: &super::Buffer,
+            index_format: wgt::IndexFormat,
             offset: wgt::BufferAddress,
             size: Option<wgt::BufferSize>,
         ) {
-            wgpu_render_pass_set_index_buffer(self, buffer.id, offset, size)
+            wgpu_render_pass_set_index_buffer(self, buffer.id, index_format, offset, size)
         }
         fn set_vertex_buffer(
             &mut self,
@@ -415,10 +416,11 @@ mod pass_impl {
         fn set_index_buffer(
             &mut self,
             buffer: &super::Buffer,
+            index_format: wgt::IndexFormat,
             offset: wgt::BufferAddress,
             size: Option<wgt::BufferSize>,
         ) {
-            wgpu_render_bundle_set_index_buffer(self, buffer.id, offset, size)
+            wgpu_render_bundle_set_index_buffer(self, buffer.id, index_format, offset, size)
         }
         fn set_vertex_buffer(
             &mut self,

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -142,6 +142,7 @@ impl crate::RenderInner<Context> for RenderPass {
     fn set_index_buffer(
         &mut self,
         buffer: &Sendable<web_sys::GpuBuffer>,
+        index_format: wgt::IndexFormat,
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) {
@@ -266,6 +267,7 @@ impl crate::RenderInner<Context> for RenderBundleEncoder {
     fn set_index_buffer(
         &mut self,
         buffer: &Sendable<web_sys::GpuBuffer>,
+        index_format: wgt::IndexFormat,
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferSize>,
     ) {
@@ -691,7 +693,11 @@ fn map_vertex_state_descriptor(
         .collect::<js_sys::Array>();
 
     let mut mapped = web_sys::GpuVertexStateDescriptor::new();
-    mapped.index_format(map_index_format(desc.vertex_state.index_format));
+    mapped.index_format(map_index_format(
+        desc.vertex_state
+            .index_format
+            .unwrap_or(wgt::IndexFormat::Uint16),
+    ));
     mapped.vertex_buffers(&mapped_vertex_buffers);
     mapped
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ trait RenderInner<Ctx: Context> {
     fn set_index_buffer(
         &mut self,
         buffer: &Ctx::BufferId,
+        index_format: IndexFormat,
         offset: BufferAddress,
         size: Option<BufferSize>,
     );
@@ -1190,7 +1191,7 @@ pub struct VertexBufferDescriptor<'a> {
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct VertexStateDescriptor<'a> {
     /// The format of any index buffers used with this pipeline.
-    pub index_format: IndexFormat,
+    pub index_format: Option<IndexFormat>,
     /// The format of any vertex buffers used with this pipeline.
     pub vertex_buffers: &'a [VertexBufferDescriptor<'a>],
 }
@@ -1984,10 +1985,11 @@ impl<'a> RenderPass<'a> {
     ///
     /// Subsequent calls to [`draw_indexed`](RenderPass::draw_indexed) on this [`RenderPass`] will
     /// use `buffer` as the source index buffer.
-    pub fn set_index_buffer(&mut self, buffer_slice: BufferSlice<'a>) {
+    pub fn set_index_buffer(&mut self, buffer_slice: BufferSlice<'a>, index_format: IndexFormat) {
         RenderInner::set_index_buffer(
             &mut self.id,
             &buffer_slice.buffer.id,
+            index_format,
             buffer_slice.offset,
             buffer_slice.size,
         )
@@ -2432,10 +2434,11 @@ impl<'a> RenderBundleEncoder<'a> {
     ///
     /// Subsequent calls to [`draw_indexed`](RenderBundleEncoder::draw_indexed) on this [`RenderBundleEncoder`] will
     /// use `buffer` as the source index buffer.
-    pub fn set_index_buffer(&mut self, buffer_slice: BufferSlice<'a>) {
+    pub fn set_index_buffer(&mut self, buffer_slice: BufferSlice<'a>, index_format: IndexFormat) {
         RenderInner::set_index_buffer(
             &mut self.id,
             &buffer_slice.buffer.id,
+            index_format,
             buffer_slice.offset,
             buffer_slice.size,
         )


### PR DESCRIPTION
__Connections__
#608 https://github.com/gfx-rs/wgpu/issues/978 https://github.com/gfx-rs/wgpu/pull/1019

__Description__
Use new API from https://github.com/gfx-rs/wgpu/commit/4513fb2b83fe2cd19682ccca9c55a6995f061699 where `wgpu_render_pass_set_index_buffer` and `wgpu_render_bundle_set_index_buffer` receive an `index_format` and `VertexStateDescriptor`'s `index_format` is an `Option`. The examples were updated accordingly.