### PR TITLE
Add write_whole_texture_mips Helper

### DIFF
--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -168,7 +168,7 @@ async fn setup<E: Example>(title: &str) -> Setup {
                 label: None,
                 features: (optional_features & adapter_features) | required_features,
                 limits: needed_limits,
-                shader_validation: true,
+                shader_validation: false,
             },
             trace_dir.ok().as_ref().map(std::path::Path::new),
         )

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -4,6 +4,7 @@ mod belt;
 
 use std::{
     borrow::Cow,
+    convert::TryFrom,
     mem::{align_of, size_of},
     ptr::copy_nonoverlapping,
 };
@@ -55,6 +56,22 @@ pub fn make_spirv<'a>(data: &'a [u8]) -> super::ShaderSource<'a> {
 pub trait DeviceExt {
     /// Creates a [`Buffer`] with data to initialize it.
     fn create_buffer_init(&self, desc: &BufferInitDescriptor) -> crate::Buffer;
+
+    /// Upload an entire texture and its mipmaps from a source buffer.
+    ///
+    /// Expects all mipmaps to be tightly packed in the data buffer.
+    ///
+    /// If the texture is a 2DArray texture, uploads each layer in order, expecting
+    /// each layer and its mips to be tightly packed.
+    ///
+    /// Example:
+    /// Layer0Mip0 Layer0Mip1 Layer0Mip2 ... Layer1Mip0 Layer1Mip1 Layer1Mip2 ...  
+    fn create_texture_with_data(
+        &self,
+        queue: &crate::Queue,
+        desc: &crate::TextureDescriptor,
+        data: &[u8],
+    ) -> crate::Texture;
 }
 
 impl DeviceExt for crate::Device {
@@ -85,6 +102,77 @@ impl DeviceExt for crate::Device {
         }
         buffer.unmap();
         buffer
+    }
+
+    fn create_texture_with_data(
+        &self,
+        queue: &crate::Queue,
+        desc: &crate::TextureDescriptor,
+        data: &[u8],
+    ) -> crate::Texture {
+        let texture = self.create_texture(desc);
+
+        let format_info = desc.format.describe();
+
+        let (layer_iterations, mip_extent) = if desc.dimension == crate::TextureDimension::D3 {
+            (1, desc.size)
+        } else {
+            (
+                desc.size.depth,
+                crate::Extent3d {
+                    depth: 1,
+                    ..desc.size
+                },
+            )
+        };
+
+        let mip_level_count =
+            u8::try_from(desc.mip_level_count).expect("mip level count overflows a u8");
+
+        let mut binary_offset = 0;
+        for layer in 0..layer_iterations {
+            for mip in 0..mip_level_count {
+                let mip_size = mip_extent.at_mip_level(mip).unwrap();
+
+                // When uploading mips of compressed textures and the mip is supposed to be
+                // a size that isn't a multiple of the block size, the mip needs to be uploaded
+                // as it's "physical size" which is the size rounded up to the nearest block size.
+                let mip_physical = mip_size.physical_size(desc.format);
+
+                // All these calculations are performed on the physical size as that's the
+                // data that exists in the buffer.
+                let width_blocks = mip_physical.width / format_info.block_dimensions.0 as u32;
+                let height_blocks = mip_physical.height / format_info.block_dimensions.1 as u32;
+
+                let bytes_per_row = width_blocks * format_info.block_size as u32;
+                let data_size = bytes_per_row * height_blocks;
+
+                let end_offset = binary_offset + data_size as usize;
+
+                queue.write_texture(
+                    crate::TextureCopyView {
+                        texture: &texture,
+                        mip_level: mip as u32,
+                        origin: crate::Origin3d {
+                            x: 0,
+                            y: 0,
+                            z: layer,
+                        },
+                    },
+                    &data[binary_offset..end_offset],
+                    crate::TextureDataLayout {
+                        offset: 0,
+                        bytes_per_row,
+                        rows_per_image: 0,
+                    },
+                    mip_physical,
+                );
+
+                binary_offset = end_offset;
+            }
+        }
+
+        texture
     }
 }
 


### PR DESCRIPTION
Adds a helper in QueueExt for uploading an entire texture with all of its mips. Name very bikeshedable.