### PR TITLE
Require labels for ComputePass and RenderPass 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,13 @@ vulkan-portability = ["wgc/gfx-backend-vulkan"]
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "01733a2f45143ee43d2a3473bc618fd06cfc076d"
+rev = "42a8dc5b343b1c882d7c5bb03b0718602ea03915"
 features = ["raw-window-handle"]
 
 [dependencies.wgt]
 package = "wgpu-types"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "01733a2f45143ee43d2a3473bc618fd06cfc076d"
+rev = "42a8dc5b343b1c882d7c5bb03b0718602ea03915"
 
 [dependencies]
 arrayvec = "0.5"

--- a/examples/boids/main.rs
+++ b/examples/boids/main.rs
@@ -274,6 +274,7 @@ impl framework::Example for Example {
             },
         }];
         let render_pass_descriptor = wgpu::RenderPassDescriptor {
+            label: None,
             color_attachments: &color_attachments,
             depth_stencil_attachment: None,
         };
@@ -285,7 +286,8 @@ impl framework::Example for Example {
         command_encoder.push_debug_group("compute boid movement");
         {
             // compute pass
-            let mut cpass = command_encoder.begin_compute_pass();
+            let mut cpass =
+                command_encoder.begin_compute_pass(&wgpu::ComputePassDescriptor { label: None });
             cpass.set_pipeline(&self.compute_pipeline);
             cpass.set_bind_group(0, &self.particle_bind_groups[self.frame_num % 2], &[]);
             cpass.dispatch(self.work_group_count, 1, 1);

--- a/examples/capture/main.rs
+++ b/examples/capture/main.rs
@@ -81,6 +81,7 @@ async fn create_red_image_with_dimensions(
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
         encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: None,
             color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                 attachment: &texture.create_view(&wgpu::TextureViewDescriptor::default()),
                 resolve_target: None,

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -390,6 +390,7 @@ impl framework::Example for Example {
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
         {
             let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: None,
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,

--- a/examples/hello-compute/main.rs
+++ b/examples/hello-compute/main.rs
@@ -131,7 +131,7 @@ async fn execute_gpu(numbers: Vec<u32>) -> Vec<u32> {
     let mut encoder =
         device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
     {
-        let mut cpass = encoder.begin_compute_pass();
+        let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor { label: None });
         cpass.set_pipeline(&compute_pipeline);
         cpass.set_bind_group(0, &bind_group, &[]);
         cpass.insert_debug_marker("compute collatz iterations");

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -1,9 +1,9 @@
+use std::borrow::Cow;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     window::Window,
 };
-use std::borrow::Cow;
 
 async fn run(event_loop: EventLoop<()>, window: Window, swapchain_format: wgpu::TextureFormat) {
     let size = window.inner_size();
@@ -84,12 +84,7 @@ async fn run(event_loop: EventLoop<()>, window: Window, swapchain_format: wgpu::
         // Have the closure take ownership of the resources.
         // `event_loop.run` never returns, therefore we must do this to ensure
         // the resources are properly cleaned up.
-        let _ = (
-            &instance,
-            &adapter,
-            &shader,
-            &pipeline_layout,
-        );
+        let _ = (&instance, &adapter, &shader, &pipeline_layout);
 
         *control_flow = ControlFlow::Poll;
         match event {
@@ -111,6 +106,7 @@ async fn run(event_loop: EventLoop<()>, window: Window, swapchain_format: wgpu::
                     device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
                 {
                     let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                        label: None,
                         color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                             attachment: &frame.view,
                             resolve_target: None,

--- a/examples/hello-windows/main.rs
+++ b/examples/hello-windows/main.rs
@@ -125,6 +125,7 @@ async fn run(
                         .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
                     {
                         let _rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                            label: None,
                             color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                                 attachment: &frame.view,
                                 resolve_target: None,

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -155,6 +155,7 @@ impl Example {
             });
 
             let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: None,
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &views[target_mip],
                     resolve_target: None,
@@ -357,6 +358,7 @@ impl framework::Example for Example {
                 a: 1.0,
             };
             let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: None,
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,

--- a/examples/msaa-line/main.rs
+++ b/examples/msaa-line/main.rs
@@ -270,6 +270,7 @@ impl framework::Example for Example {
 
             encoder
                 .begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: None,
                     color_attachments: &[rpass_color_attachment],
                     depth_stencil_attachment: None,
                 })

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -768,6 +768,7 @@ impl framework::Example for Example {
             encoder.insert_debug_marker("render entities");
             {
                 let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: None,
                     color_attachments: &[],
                     depth_stencil_attachment: Some(
                         wgpu::RenderPassDepthStencilAttachmentDescriptor {
@@ -799,6 +800,7 @@ impl framework::Example for Example {
         encoder.push_debug_group("forward rendering pass");
         {
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: None,
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -276,6 +276,7 @@ impl framework::Example for Skybox {
 
         {
             let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: None,
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,

--- a/examples/texture-arrays/main.rs
+++ b/examples/texture-arrays/main.rs
@@ -314,6 +314,7 @@ impl framework::Example for Example {
         });
 
         let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: None,
             color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                 attachment: &frame.view,
                 resolve_target: None,

--- a/examples/water/main.rs
+++ b/examples/water/main.rs
@@ -710,6 +710,7 @@ impl framework::Example for Example {
         // First pass: render the reflection.
         {
             let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: None,
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &self.reflect_view,
                     resolve_target: None,
@@ -738,6 +739,7 @@ impl framework::Example for Example {
         // depth values, so we must use StoreOp::Store.
         {
             let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: None,
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,
@@ -764,6 +766,7 @@ impl framework::Example for Example {
         // to it, so it cannot be in the same render pass.
         {
             let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: None,
                 color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                     attachment: &frame.view,
                     resolve_target: None,

--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -1,8 +1,8 @@
 use crate::{
     backend::{error::ContextError, native_gpu_future},
     BindGroupDescriptor, BindGroupLayoutDescriptor, BindingResource, CommandEncoderDescriptor,
-    ComputePipelineDescriptor, Features, Label, Limits, LoadOp, MapMode, Operations,
-    PipelineLayoutDescriptor, RenderBundleEncoderDescriptor, RenderPipelineDescriptor,
+    ComputePassDescriptor, ComputePipelineDescriptor, Features, Label, Limits, LoadOp, MapMode,
+    Operations, PipelineLayoutDescriptor, RenderBundleEncoderDescriptor, RenderPipelineDescriptor,
     SamplerDescriptor, ShaderModuleDescriptor, ShaderSource, SwapChainStatus, TextureDescriptor,
     TextureViewDescriptor,
 };
@@ -1503,8 +1503,14 @@ impl crate::Context for Context {
     fn command_encoder_begin_compute_pass(
         &self,
         encoder: &Self::CommandEncoderId,
+        desc: &ComputePassDescriptor,
     ) -> Self::ComputePassId {
-        wgc::command::ComputePass::new(encoder.id)
+        wgc::command::ComputePass::new(
+            encoder.id,
+            &wgc::command::ComputePassDescriptor {
+                label: desc.label.map(Borrowed),
+            },
+        )
     }
 
     fn command_encoder_end_compute_pass(
@@ -1553,7 +1559,8 @@ impl crate::Context for Context {
 
         wgc::command::RenderPass::new(
             encoder.id,
-            wgc::command::RenderPassDescriptor {
+            &wgc::command::RenderPassDescriptor {
+                label: desc.label.map(Borrowed),
                 color_attachments: Borrowed(&colors),
                 depth_stencil_attachment: depth_stencil.as_ref(),
             },

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -1,10 +1,10 @@
 use crate::{
     BindGroupDescriptor, BindGroupLayoutDescriptor, BindingResource, BindingType,
-    BufferBindingType, BufferDescriptor, CommandEncoderDescriptor, ComputePipelineDescriptor,
-    LoadOp, PipelineLayoutDescriptor, ProgrammableStageDescriptor, RenderBundleEncoderDescriptor,
-    RenderPipelineDescriptor, SamplerDescriptor, ShaderModuleDescriptor, ShaderSource,
-    StorageTextureAccess, SwapChainStatus, TextureDescriptor, TextureViewDescriptor,
-    TextureViewDimension,
+    BufferBindingType, BufferDescriptor, CommandEncoderDescriptor, ComputePassDescriptor,
+    ComputePipelineDescriptor, LoadOp, PipelineLayoutDescriptor, ProgrammableStageDescriptor,
+    RenderBundleEncoderDescriptor, RenderPipelineDescriptor, SamplerDescriptor,
+    ShaderModuleDescriptor, ShaderSource, StorageTextureAccess, SwapChainStatus, TextureDescriptor,
+    TextureViewDescriptor, TextureViewDimension,
 };
 
 use futures::FutureExt;
@@ -972,9 +972,7 @@ impl crate::Context for Context {
             ShaderSource::SpirV(ref spv) => {
                 web_sys::GpuShaderModuleDescriptor::new(&js_sys::Uint32Array::from(&**spv))
             }
-            ShaderSource::Wgsl(_) => {
-                panic!("WGSL is not yet supported by the Web backend")
-            }
+            ShaderSource::Wgsl(_) => panic!("WGSL is not yet supported by the Web backend"),
         };
         if let Some(ref label) = desc.label {
             descriptor.label(label);
@@ -1546,9 +1544,10 @@ impl crate::Context for Context {
     fn command_encoder_begin_compute_pass(
         &self,
         encoder: &Self::CommandEncoderId,
+        desc: &ComputePassDescriptor,
     ) -> Self::ComputePassId {
         let mut mapped_desc = web_sys::GpuComputePassDescriptor::new();
-        if let Some(ref label) = encoder.label() {
+        if let Some(ref label) = desc.label {
             mapped_desc.label(label);
         }
         ComputePass(encoder.begin_compute_pass_with_descriptor(&mapped_desc))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,6 +359,7 @@ trait Context: Debug + Send + Sized + Sync {
     fn command_encoder_begin_compute_pass(
         &self,
         encoder: &Self::CommandEncoderId,
+        desc: &ComputePassDescriptor,
     ) -> Self::ComputePassId;
     fn command_encoder_end_compute_pass(
         &self,
@@ -1115,6 +1116,8 @@ pub struct ProgrammableStageDescriptor<'a> {
 /// Describes the attachments of a render pass.
 #[derive(Clone, Debug, Default)]
 pub struct RenderPassDescriptor<'a, 'b> {
+    /// Debug label of the render pass. This will show up in graphics debuggers for easy identification.
+    pub label: Option<&'a str>,
     /// The color attachments of the render pass.
     pub color_attachments: &'b [RenderPassColorAttachmentDescriptor<'a>],
     /// The depth and stencil attachment of the render pass, if any.
@@ -1155,6 +1158,13 @@ pub struct RenderPipelineDescriptor<'a> {
     /// The implicit mask produced for alpha of zero is guaranteed to be zero, and for alpha of one
     /// is guaranteed to be all 1-s.
     pub alpha_to_coverage_enabled: bool,
+}
+
+/// Describes the attachments of a compute pass.
+#[derive(Clone, Debug, Default)]
+pub struct ComputePassDescriptor<'a> {
+    /// Debug label of the compute pass. This will show up in graphics debuggers for easy identification.
+    pub label: Option<&'a str>,
 }
 
 /// Describes a compute pipeline.
@@ -1848,9 +1858,9 @@ impl CommandEncoder {
     /// Begins recording of a compute pass.
     ///
     /// This function returns a [`ComputePass`] object which records a single compute pass.
-    pub fn begin_compute_pass(&mut self) -> ComputePass {
+    pub fn begin_compute_pass(&mut self, desc: &ComputePassDescriptor) -> ComputePass {
         ComputePass {
-            id: Context::command_encoder_begin_compute_pass(&*self.context, &self.id),
+            id: Context::command_encoder_begin_compute_pass(&*self.context, &self.id, desc),
             parent: self,
         }
     }


### PR DESCRIPTION
Blocked on https://github.com/gfx-rs/wgpu/pull/1088/

https://github.com/gfx-rs/wgpu/pull/1088/ improved labelling, update `wgpu-rs` and examples to match.

Change-Id: I1acc45a3023dfc78b6694bd4a28a0131f07b7ba7