### PR TITLE
Replace futures crate with pollster.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ rev = "4ebe1f50b057046e4d4f015eb006330d62f5fe91"
 
 [dependencies]
 arrayvec = "0.5"
-futures = { version = "0.3", default-features = false, features = ["std"] }
 parking_lot = "0.11"
 raw-window-handle = "0.3"
 smallvec = "1"
@@ -60,7 +59,10 @@ rand = { version = "0.7.2", features = ["wasm-bindgen"] }
 bytemuck = { version = "1.4", features = ["derive"] }
 noise = "0.6"
 ddsfile = "0.4"
-futures = { version = "0.3", default-features = false, features = ["std", "executor"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+async-executor = "1.0"
+pollster = "0.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies.wgpu-subscriber]
 version = "0.1"

--- a/examples/boids/main.rs
+++ b/examples/boids/main.rs
@@ -262,7 +262,7 @@ impl framework::Example for Example {
         frame: &wgpu::SwapChainTexture,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-        _spawner: &impl futures::task::LocalSpawn,
+        _spawner: &framework::Spawner,
     ) {
         // create render pass descriptor and its color attachments
         let color_attachments = [wgpu::RenderPassColorAttachmentDescriptor {

--- a/examples/capture/main.rs
+++ b/examples/capture/main.rs
@@ -195,7 +195,7 @@ fn main() {
     #[cfg(not(target_arch = "wasm32"))]
     {
         wgpu_subscriber::initialize_default_subscriber(None);
-        futures::executor::block_on(run("red.png"));
+        pollster::block_on(run("red.png"));
     }
     #[cfg(target_arch = "wasm32")]
     {
@@ -212,7 +212,7 @@ mod tests {
 
     #[test]
     fn ensure_generated_data_matches_expected() {
-        futures::executor::block_on(assert_generated_data_matches_expected());
+        pollster::block_on(assert_generated_data_matches_expected());
     }
 
     async fn assert_generated_data_matches_expected() {

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -384,7 +384,7 @@ impl framework::Example for Example {
         frame: &wgpu::SwapChainTexture,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-        _spawner: &impl futures::task::LocalSpawn,
+        _spawner: &framework::Spawner,
     ) {
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });

--- a/examples/hello-compute/main.rs
+++ b/examples/hello-compute/main.rs
@@ -183,7 +183,7 @@ fn main() {
     #[cfg(not(target_arch = "wasm32"))]
     {
         wgpu_subscriber::initialize_default_subscriber(None);
-        futures::executor::block_on(run());
+        pollster::block_on(run());
     }
     #[cfg(target_arch = "wasm32")]
     {
@@ -193,20 +193,20 @@ fn main() {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
 
     #[test]
     fn test_compute_1() {
         let input = vec![1, 2, 3, 4];
-        futures::executor::block_on(assert_execute_gpu(input, vec![0, 1, 7, 2]));
+        pollster::block_on(assert_execute_gpu(input, vec![0, 1, 7, 2]));
     }
 
     #[test]
     fn test_compute_2() {
         let input = vec![5, 23, 10, 9];
-        futures::executor::block_on(assert_execute_gpu(input, vec![5, 15, 6, 19]));
+        pollster::block_on(assert_execute_gpu(input, vec![5, 15, 6, 19]));
     }
 
     #[test]
@@ -220,7 +220,7 @@ mod tests {
             let tx = tx.clone();
             thread::spawn(move || {
                 let input = vec![100, 100, 100];
-                futures::executor::block_on(assert_execute_gpu(input, vec![25, 25, 25]));
+                pollster::block_on(assert_execute_gpu(input, vec![25, 25, 25]));
                 tx.send(true).unwrap();
             });
         }

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -140,7 +140,7 @@ fn main() {
     {
         wgpu_subscriber::initialize_default_subscriber(None);
         // Temporarily avoid srgb formats for the swapchain on the web
-        futures::executor::block_on(run(event_loop, window));
+        pollster::block_on(run(event_loop, window));
     }
     #[cfg(target_arch = "wasm32")]
     {

--- a/examples/hello-windows/main.rs
+++ b/examples/hello-windows/main.rs
@@ -191,7 +191,7 @@ fn main() {
 
         wgpu_subscriber::initialize_default_subscriber(None);
         // Temporarily avoid srgb formats for the swapchain on the web
-        futures::executor::block_on(run(event_loop, viewports));
+        pollster::block_on(run(event_loop, viewports));
     }
     #[cfg(target_arch = "wasm32")]
     {

--- a/examples/hello/main.rs
+++ b/examples/hello/main.rs
@@ -14,7 +14,7 @@ fn main() {
     #[cfg(not(target_arch = "wasm32"))]
     {
         wgpu_subscriber::initialize_default_subscriber(None);
-        futures::executor::block_on(run());
+        pollster::block_on(run());
     }
     #[cfg(target_arch = "wasm32")]
     {

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -346,7 +346,7 @@ impl framework::Example for Example {
         frame: &wgpu::SwapChainTexture,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-        _spawner: &impl futures::task::LocalSpawn,
+        _spawner: &framework::Spawner,
     ) {
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });

--- a/examples/msaa-line/main.rs
+++ b/examples/msaa-line/main.rs
@@ -231,7 +231,7 @@ impl framework::Example for Example {
         frame: &wgpu::SwapChainTexture,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-        _spawner: &impl futures::task::LocalSpawn,
+        _spawner: &framework::Spawner,
     ) {
         if self.rebuild_bundle {
             self.bundle = Example::create_bundle(

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -710,7 +710,7 @@ impl framework::Example for Example {
         frame: &wgpu::SwapChainTexture,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-        _spawner: &impl futures::task::LocalSpawn,
+        _spawner: &framework::Spawner,
     ) {
         // update uniforms
         for entity in self.entities.iter_mut() {

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -1,7 +1,6 @@
 #[path = "../framework.rs"]
 mod framework;
 
-use futures::task::{LocalSpawn, LocalSpawnExt};
 use wgpu::util::DeviceExt;
 
 const IMAGE_SIZE: u32 = 128;
@@ -253,7 +252,7 @@ impl framework::Example for Skybox {
         frame: &wgpu::SwapChainTexture,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-        spawner: &impl LocalSpawn,
+        spawner: &framework::Spawner,
     ) {
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
@@ -301,7 +300,7 @@ impl framework::Example for Skybox {
         queue.submit(std::iter::once(encoder.finish()));
 
         let belt_future = self.staging_belt.recall();
-        spawner.spawn_local(belt_future).unwrap();
+        spawner.spawn_local(belt_future);
     }
 }
 

--- a/examples/texture-arrays/main.rs
+++ b/examples/texture-arrays/main.rs
@@ -307,7 +307,7 @@ impl framework::Example for Example {
         frame: &wgpu::SwapChainTexture,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-        _spawner: &impl futures::task::LocalSpawn,
+        _spawner: &framework::Spawner,
     ) {
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("primary"),

--- a/examples/water/main.rs
+++ b/examples/water/main.rs
@@ -673,7 +673,7 @@ impl framework::Example for Example {
         frame: &wgpu::SwapChainTexture,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-        _spawner: &impl futures::task::LocalSpawn,
+        _spawner: &framework::Spawner,
     ) {
         // Increment frame count regardless of if we draw.
         self.current_frame += 1;

--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -8,11 +8,17 @@ use crate::{
 };
 
 use arrayvec::ArrayVec;
-use futures::future::{ready, Ready};
 use parking_lot::Mutex;
 use smallvec::SmallVec;
 use std::{
-    borrow::Cow::Borrowed, error::Error, fmt, marker::PhantomData, ops::Range, slice, sync::Arc,
+    borrow::Cow::Borrowed,
+    error::Error,
+    fmt,
+    future::{ready, Ready},
+    marker::PhantomData,
+    ops::Range,
+    slice,
+    sync::Arc,
 };
 use typed_arena::Arena;
 


### PR DESCRIPTION
This PR removes all of the `futures` dependencies. `std::future` does not contain a lot of useful helpers available in `futures`. The obvious ones are `join_all`, `FutureExt::map`, and `block_on`.

- `join_all` is replaced with a `Vec<T>` and an `async` block.
- `FuturesExt::map` in the web backend is replaced by rolling the `map` function into the `MakeSendFuture` type.
- `block_on` is provided by `pollster`.

The original code using `join_all` ignored the result type yielded by the Future from `map_async`. This code does the same, but makes dropping the result a little more obvious.

These should not be troublesome. Figured I would call them out anyway.

The last big change is replacing `futures-executor` in the examples with `async-executor`. A new concrete `Spawner` type is used in the example framework instead of an implementation of `futures_task::LocalSpawn`.

Fixes #628