### PR TITLE
Use only 1 and 4 samples for msaa-line example

### DIFF
--- a/examples/msaa-line/main.rs
+++ b/examples/msaa-line/main.rs
@@ -193,15 +193,17 @@ impl framework::Example for Example {
             winit::event::WindowEvent::KeyboardInput { input, .. } => {
                 if let winit::event::ElementState::Pressed = input.state {
                     match input.virtual_keycode {
+                        // TODO: Switch back to full scans of possible options when we expose
+                        //       supported sample counts to the user.
                         Some(winit::event::VirtualKeyCode::Left) => {
-                            if self.sample_count >= 2 {
-                                self.sample_count = self.sample_count >> 1;
+                            if self.sample_count == 4 {
+                                self.sample_count = 1;
                                 self.rebuild_bundle = true;
                             }
                         }
                         Some(winit::event::VirtualKeyCode::Right) => {
-                            if self.sample_count <= 16 {
-                                self.sample_count = self.sample_count << 1;
+                            if self.sample_count == 1 {
+                                self.sample_count = 4;
                                 self.rebuild_bundle = true;
                             }
                         }


### PR DESCRIPTION
Fixes #91

As 1 and 4 samples are the only universally supported values, switch the msaa-line example to only using them. In the future where users can determine the supported sample counts. See https://github.com/gfx-rs/wgpu/issues/804