### PR TITLE
Expose get_swap_chain_preferred_format

### DIFF
--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -224,12 +224,7 @@ fn start<E: Example>(
 
     let mut sc_desc = wgpu::SwapChainDescriptor {
         usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
-        // TODO: Allow srgb unconditionally
-        format: if cfg!(target_arch = "wasm32") {
-            wgpu::TextureFormat::Bgra8Unorm
-        } else {
-            wgpu::TextureFormat::Bgra8UnormSrgb
-        },
+        format: device.get_swap_chain_preferred_format(),
         width: size.width,
         height: size.height,
         present_mode: wgpu::PresentMode::Mailbox,

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -5,7 +5,7 @@ use winit::{
     window::Window,
 };
 
-async fn run(event_loop: EventLoop<()>, window: Window, swapchain_format: wgpu::TextureFormat) {
+async fn run(event_loop: EventLoop<()>, window: Window) {
     let size = window.inner_size();
     let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
     let surface = unsafe { instance.create_surface(&window) };
@@ -43,6 +43,8 @@ async fn run(event_loop: EventLoop<()>, window: Window, swapchain_format: wgpu::
         bind_group_layouts: &[],
         push_constant_ranges: &[],
     });
+
+    let swapchain_format = device.get_swap_chain_preferred_format();
 
     let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
         label: None,
@@ -138,7 +140,7 @@ fn main() {
     {
         subscriber::initialize_default_subscriber(None);
         // Temporarily avoid srgb formats for the swapchain on the web
-        futures::executor::block_on(run(event_loop, window, wgpu::TextureFormat::Bgra8UnormSrgb));
+        futures::executor::block_on(run(event_loop, window));
     }
     #[cfg(target_arch = "wasm32")]
     {
@@ -154,6 +156,6 @@ fn main() {
                     .ok()
             })
             .expect("couldn't append canvas to document body");
-        wasm_bindgen_futures::spawn_local(run(event_loop, window, wgpu::TextureFormat::Bgra8Unorm));
+        wasm_bindgen_futures::spawn_local(run(event_loop, window));
     }
 }

--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -4,7 +4,7 @@ use crate::{
     CommandEncoderDescriptor, ComputePassDescriptor, ComputePipelineDescriptor, Features, Label,
     Limits, LoadOp, MapMode, Operations, PipelineLayoutDescriptor, RenderBundleEncoderDescriptor,
     RenderPipelineDescriptor, SamplerDescriptor, ShaderModuleDescriptor, ShaderSource,
-    SwapChainStatus, TextureDescriptor, TextureViewDescriptor,
+    SwapChainStatus, TextureDescriptor, TextureFormat, TextureViewDescriptor,
 };
 
 use arrayvec::ArrayVec;
@@ -704,6 +704,15 @@ impl crate::Context for Context {
         match wgc::gfx_select!(device.id => global.device_limits(device.id)) {
             Ok(limits) => limits,
             Err(err) => self.handle_error_fatal(err, "Device::limits"),
+        }
+    }
+
+    fn device_get_swap_chain_preferred_format(&self, device: &Self::DeviceId) -> TextureFormat {
+        let global = &self.0;
+        match wgc::gfx_select!(device.id => global.device_get_swap_chain_preferred_format(device.id))
+        {
+            Ok(swap_chain_preferred_format) => swap_chain_preferred_format,
+            Err(err) => self.handle_error_fatal(err, "Device::get_swap_chain_preferred_format"),
         }
     }
 

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -962,6 +962,14 @@ impl crate::Context for Context {
         wgt::Limits::default()
     }
 
+    fn device_get_swap_chain_preferred_format(
+        &self,
+        device: &Self::DeviceId,
+    ) -> wgt::TextureFormat {
+        // TODO: web-sys bindings need to be updated to not return a promise
+        wgt::TextureFormat::Bgra8Unorm
+    }
+
     fn device_create_swap_chain(
         &self,
         device: &Self::DeviceId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,7 @@ trait Context: Debug + Send + Sized + Sync {
 
     fn device_features(&self, device: &Self::DeviceId) -> Features;
     fn device_limits(&self, device: &Self::DeviceId) -> Limits;
+    fn device_get_swap_chain_preferred_format(&self, device: &Self::DeviceId) -> TextureFormat;
     fn device_create_swap_chain(
         &self,
         device: &Self::DeviceId,
@@ -1426,6 +1427,11 @@ impl Device {
     /// If any of these limits are exceeded, functions may panic.
     pub fn limits(&self) -> Limits {
         Context::device_limits(&*self.context, &self.id)
+    }
+
+    /// Returns an optimal texture format to use for the [`SwapChain`] with this device.
+    pub fn get_swap_chain_preferred_format(&self) -> TextureFormat {
+        Context::device_get_swap_chain_preferred_format(&*self.context, &self.id)
     }
 
     /// Creates a shader module from either SPIR-V or WGSL source code.


### PR DESCRIPTION
Fixes #691

This functionality was committed in gfx-rs/wgpu@6f1d614 but never exposed to `wgpu-rs`.

Problem: Examples made use of `wgpu::TextureFormat::Bgra8UnormSrgb` but that's unreliable and according to the [API](https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-getswapchainpreferredformat) this method is the way of properly obtaining an optimal texture format for the `SwapChain` based on the platform.

- [x]  Expose `get_swap_chain_preferred_format()` on Device
- [x]  Use `TextureFormat::Bgra8Unorm` for [web.rs](https://github.com/gfx-rs/wgpu-rs/blob/e00ef5d5842a1fcfb46bb531789b1c340bdee3ab/src/backend/web.rs#L970)
- [x]  Update [framework.rs](https://github.com/gfx-rs/wgpu-rs/blob/e00ef5d5842a1fcfb46bb531789b1c340bdee3ab/examples/framework.rs#L227) and examples to call this new method