### PR TITLE
Remove wgpu-subscriber -> subscriber alias in examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,7 @@ noise = "0.6"
 ddsfile = "0.4"
 futures = { version = "0.3", default-features = false, features = ["std", "executor"] }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies.subscriber]
-package = "wgpu-subscriber"
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies.wgpu-subscriber]
 version = "0.1"
 
 [[example]]

--- a/examples/capture/main.rs
+++ b/examples/capture/main.rs
@@ -194,7 +194,7 @@ impl BufferDimensions {
 fn main() {
     #[cfg(not(target_arch = "wasm32"))]
     {
-        subscriber::initialize_default_subscriber(None);
+        wgpu_subscriber::initialize_default_subscriber(None);
         futures::executor::block_on(run("red.png"));
     }
     #[cfg(target_arch = "wasm32")]

--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -75,7 +75,7 @@ async fn setup<E: Example>(title: &str) -> Setup {
     #[cfg(not(target_arch = "wasm32"))]
     {
         let chrome_tracing_dir = std::env::var("WGPU_CHROME_TRACE");
-        subscriber::initialize_default_subscriber(
+        wgpu_subscriber::initialize_default_subscriber(
             chrome_tracing_dir.as_ref().map(std::path::Path::new).ok(),
         );
     };

--- a/examples/hello-compute/main.rs
+++ b/examples/hello-compute/main.rs
@@ -182,7 +182,7 @@ async fn execute_gpu(numbers: Vec<u32>) -> Vec<u32> {
 fn main() {
     #[cfg(not(target_arch = "wasm32"))]
     {
-        subscriber::initialize_default_subscriber(None);
+        wgpu_subscriber::initialize_default_subscriber(None);
         futures::executor::block_on(run());
     }
     #[cfg(target_arch = "wasm32")]

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -138,7 +138,7 @@ fn main() {
     let window = winit::window::Window::new(&event_loop).unwrap();
     #[cfg(not(target_arch = "wasm32"))]
     {
-        subscriber::initialize_default_subscriber(None);
+        wgpu_subscriber::initialize_default_subscriber(None);
         // Temporarily avoid srgb formats for the swapchain on the web
         futures::executor::block_on(run(event_loop, window));
     }

--- a/examples/hello-windows/main.rs
+++ b/examples/hello-windows/main.rs
@@ -189,7 +189,7 @@ fn main() {
             }
         }
 
-        subscriber::initialize_default_subscriber(None);
+        wgpu_subscriber::initialize_default_subscriber(None);
         // Temporarily avoid srgb formats for the swapchain on the web
         futures::executor::block_on(run(event_loop, viewports));
     }

--- a/examples/hello/main.rs
+++ b/examples/hello/main.rs
@@ -13,7 +13,7 @@ async fn run() {
 fn main() {
     #[cfg(not(target_arch = "wasm32"))]
     {
-        subscriber::initialize_default_subscriber(None);
+        wgpu_subscriber::initialize_default_subscriber(None);
         futures::executor::block_on(run());
     }
     #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
Fixes #686

> All examples should be able to be copied into their own project and missing crates filled in based on errors alone.