### PR TITLE
Fix cargo doc warnings due to unresolved links

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,7 +520,7 @@ impl MapContext {
 
 /// Handle to a GPU-accessible buffer.
 ///
-/// Created with [`Device::create_buffer`] or [`Device::create_buffer_init`]
+/// Created with [`Device::create_buffer`] or [DeviceExt::create_buffer_init](util::DeviceExt::create_buffer_init)
 #[derive(Debug)]
 pub struct Buffer {
     context: Arc<C>,
@@ -876,7 +876,7 @@ pub struct Queue {
 pub enum BindingResource<'a> {
     /// Binding is backed by a buffer.
     ///
-    /// Corresponds to [`BindingType::UniformBuffer`] and [`BindingType::StorageBuffer`]
+    /// Corresponds to [`wgt::BufferBindingType::Uniform`] and [`wgt::BufferBindingType::Storage`]
     /// with [`BindGroupLayoutEntry::count`] set to None.
     Buffer {
         /// The buffer to bind.
@@ -891,18 +891,18 @@ pub enum BindingResource<'a> {
     },
     /// Binding is a sampler.
     ///
-    /// Corresponds to [`BindingType::Sampler`] with [`BindGroupLayoutEntry::count`] set to None.
+    /// Corresponds to [`wgt::BindingType::Sampler`] with [`BindGroupLayoutEntry::count`] set to None.
     Sampler(&'a Sampler),
     /// Binding is backed by a texture.
     ///
-    /// Corresponds to [`BindingType::SampledTexture`] and [`BindingType::StorageTexture`] with
+    /// Corresponds to [`wgt::BindingType::Texture`] and [`wgt::BindingType::StorageTexture`] with
     /// [`BindGroupLayoutEntry::count`] set to None.
     TextureView(&'a TextureView),
     /// Binding is backed by an array of textures.
     ///
     /// [`Features::SAMPLED_TEXTURE_BINDING_ARRAY`] must be supported to use this feature.
     ///
-    /// Corresponds to [`BindingType::SampledTexture`] and [`BindingType::StorageTexture`] with
+    /// Corresponds to [`wgt::BindingType::Texture`] and [`wgt::BindingType::StorageTexture`] with
     /// [`BindGroupLayoutEntry::count`] set to Some.
     TextureViewArray(&'a [&'a TextureView]),
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,13 +1,13 @@
 //! Convenience macros
 
-/// Macro to produce an array of [`VertexAttributeDescriptor`].
+/// Macro to produce an array of [VertexAttributeDescriptor](crate::VertexAttributeDescriptor).
 ///
 /// Output has type: `[VertexAttributeDescriptor; _]`. Usage is as follows:
 /// ```
 /// # use wgpu::vertex_attr_array;
 /// let attrs = vertex_attr_array![0 => Float2, 1 => Float, 2 => Ushort4];
 /// ```
-/// This example specifies a list of three [`VertexAttributeDescriptor`],
+/// This example specifies a list of three [VertexAttributeDescriptor](crate::VertexAttributeDescriptor),
 /// each with the given `shader_location` and `format`.
 /// Offsets are calculated automatically.
 #[macro_export]

--- a/src/util/device.rs
+++ b/src/util/device.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-/// Describes a [`Buffer`] when allocating.
+/// Describes a [Buffer](crate::Buffer) when allocating.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct BufferInitDescriptor<'a> {
     /// Debug label of a buffer. This will show up in graphics debuggers for easy identification.
@@ -14,7 +14,7 @@ pub struct BufferInitDescriptor<'a> {
 
 /// Utility methods not meant to be in the main API.
 pub trait DeviceExt {
-    /// Creates a [`Buffer`] with data to initialize it.
+    /// Creates a [Buffer](crate::Buffer) with data to initialize it.
     fn create_buffer_init(&self, desc: &BufferInitDescriptor) -> crate::Buffer;
 
     /// Upload an entire texture and its mipmaps from a source buffer.

--- a/src/util/encoder.rs
+++ b/src/util/encoder.rs
@@ -29,7 +29,7 @@ pub trait RenderEncoder<'a> {
     /// [`RenderBundleEncoder`] will use `buffer` as one of the source vertex buffers.
     ///
     /// The `slot` refers to the index of the matching descriptor in
-    /// [`VertexStateDescriptor::vertex_buffers`].
+    /// [VertexStateDescriptor::vertex_buffers](crate::VertexStateDescriptor::vertex_buffers).
     ///
     /// [`draw`]: RenderBundleEncoder::draw
     /// [`draw_indexed`]: RenderBundleEncoder::draw_indexed
@@ -87,11 +87,11 @@ pub trait RenderEncoder<'a> {
         indirect_offset: BufferAddress,
     );
 
-    /// [`Features::PUSH_CONSTANTS`] must be enabled on the device in order to call this function.
+    /// [`wgt::Features::PUSH_CONSTANTS`] must be enabled on the device in order to call this function.
     ///
     /// Set push constant data.
     ///
-    /// Offset is measured in bytes, but must be a multiple of [`PUSH_CONSTANT_ALIGNMENT`].
+    /// Offset is measured in bytes, but must be a multiple of [`wgt::PUSH_CONSTANT_ALIGNMENT`].
     ///
     /// Data size must be a multiple of 4 and must be aligned to the 4s, so we take an array of u32.
     /// For example, with an offset of 4 and an array of `[u32; 3]`, that will write to the range


### PR DESCRIPTION
This PR fixes 13 warnings caused by unresolved internal and external(wgt) links in `cargo doc`.

> <img width="800" alt="Screenshot 2021-01-06 at 18 33 00" src="https://user-images.githubusercontent.com/13288771/103807298-809b4100-5056-11eb-8667-752f4bdd7902.png">
