### PR TITLE
Fix compilation on aarch64-apple-darwin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 cgmath = "0.17"
 log = "0.4"
 png = "0.16"
-winit = { version = "0.23.0", features = ["web-sys"] }
+winit = { version = "0.24.0", features = ["web-sys"] }
 rand = { version = "0.7.2", features = ["wasm-bindgen"] }
 bytemuck = { version = "1.4", features = ["derive"] }
 noise = "0.6"


### PR DESCRIPTION
wgpu-rs couldn't compile on the Apple M1 (arm64) macs due to a compilation
problem in winit.  winit 0.24.0 has the fix so upgrade the dependency.

Link to the fix's pull request in winit:
   https://github.com/rust-windowing/winit/pull/1752