### PR TITLE
Expose texture format feature query (and update to latest wgpu)

### DIFF
--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -710,6 +710,19 @@ impl crate::Context for Context {
         }
     }
 
+    fn adapter_get_texture_format_features(
+        &self,
+        adapter: &Self::AdapterId,
+        format: wgt::TextureFormat,
+    ) -> wgt::TextureFormatFeatures {
+        let global = &self.0;
+        match wgc::gfx_select!(*adapter => global.adapter_get_texture_format_features(*adapter, format))
+        {
+            Ok(info) => info,
+            Err(err) => self.handle_error_fatal(err, "Adapter::get_texture_format_features"),
+        }
+    }
+
     fn device_features(&self, device: &Self::DeviceId) -> Features {
         let global = &self.0;
         match wgc::gfx_select!(device.id => global.device_features(device.id)) {

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -984,6 +984,14 @@ impl crate::Context for Context {
         }
     }
 
+    fn adapter_get_texture_format_features(
+        &self,
+        _adapter: &Self::AdapterId,
+        format: wgt::TextureFormat,
+    ) -> wgt::TextureFormatFeatures {
+        format.describe().guaranteed_format_features
+    }
+
     fn device_features(&self, _device: &Self::DeviceId) -> wgt::Features {
         // TODO: web-sys has no way of getting extensions on devices
         wgt::Features::empty()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,11 @@ trait Context: Debug + Send + Sized + Sync {
     fn adapter_features(&self, adapter: &Self::AdapterId) -> Features;
     fn adapter_limits(&self, adapter: &Self::AdapterId) -> Limits;
     fn adapter_get_info(&self, adapter: &Self::AdapterId) -> AdapterInfo;
+    fn adapter_get_texture_format_features(
+        &self,
+        adapter: &Self::AdapterId,
+        format: wgt::TextureFormat,
+    ) -> wgt::TextureFormatFeatures;
 
     fn device_features(&self, device: &Self::DeviceId) -> Features;
     fn device_limits(&self, device: &Self::DeviceId) -> Limits;
@@ -1412,6 +1417,17 @@ impl Adapter {
     /// Get info about the adapter itself.
     pub fn get_info(&self) -> AdapterInfo {
         Context::adapter_get_info(&*self.context, &self.id)
+    }
+
+    /// Returns the features supported for a given texture format by this adapter.
+    ///
+    /// Note that the WebGPU spec further restricts the available usages/features.
+    /// To disable these restrictions on a device, request the [`Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`] feature.
+    pub fn get_texture_format_features(
+        &self,
+        format: wgt::TextureFormat,
+    ) -> wgt::TextureFormatFeatures {
+        Context::adapter_get_texture_format_features(&*self.context, &self.id, format)
     }
 }
 


### PR DESCRIPTION
Exposes texture format feature query from https://github.com/gfx-rs/wgpu/pull/1112
Updating wgpu-core led to breaking change of moving get_swap_chain_preferred_format from device to adapter.