### PR TITLE
Bump wgpu-core and update texture_view_drop call

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,20 +26,20 @@ webgl = ["wgc"]
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "7c9e239a2400fab89fcf905ac42be0360224a522"
+rev = "b23ece55e7abb8d449fcae09398b2402b0efee99"
 features = ["raw-window-handle"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "7c9e239a2400fab89fcf905ac42be0360224a522"
+rev = "b23ece55e7abb8d449fcae09398b2402b0efee99"
 features = ["raw-window-handle"]
 optional = true
 
 [dependencies.wgt]
 package = "wgpu-types"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "7c9e239a2400fab89fcf905ac42be0360224a522"
+rev = "b23ece55e7abb8d449fcae09398b2402b0efee99"
 
 [dependencies]
 arrayvec = "0.5"

--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -1458,7 +1458,7 @@ impl crate::Context for Context {
     }
     fn texture_view_drop(&self, texture_view: &Self::TextureViewId) {
         let global = &self.0;
-        match wgc::gfx_select!(*texture_view => global.texture_view_drop(*texture_view)) {
+        match wgc::gfx_select!(*texture_view => global.texture_view_drop(*texture_view, false)) {
             Ok(()) => (),
             Err(err) => self.handle_error_fatal(err, "TextureView::drop"),
         }


### PR DESCRIPTION
This PR updates to the latest `wgpu-core` commit ([wgpu #1163](https://github.com/gfx-rs/wgpu/pull/1163)), and is the counterpart to [wgpu-native #66](https://github.com/gfx-rs/wgpu-native/pull/66).

I'm using `wait = false` in the `texture_view_drop` call to match `buffer_drop` and `texture_drop` elsewhere `backend/direct.rs`, though I don't quite understand the implications 😅