### PR TITLE
RFC: Continuously run poll from a background thread on native backend

### DIFF
--- a/examples/hello-compute/main.rs
+++ b/examples/hello-compute/main.rs
@@ -143,18 +143,10 @@ async fn execute_gpu(numbers: Vec<u32>) -> Vec<u32> {
     // Submits command encoder for processing
     queue.submit(Some(encoder.finish()));
 
-    // Note that we're not calling `.await` here.
     let buffer_slice = staging_buffer.slice(..);
-    // Gets the future representing when `staging_buffer` can be read from
-    let buffer_future = buffer_slice.map_async(wgpu::MapMode::Read);
 
-    // Poll the device in a blocking manner so that our future resolves.
-    // In an actual application, `device.poll(...)` should
-    // be called in an event loop or on another thread.
-    device.poll(wgpu::Maintain::Wait);
-
-    // Awaits until `buffer_future` can be read from
-    if let Ok(()) = buffer_future.await {
+    // Wait for the slice of `staging_buffer` to be mapped for reading
+    if let Ok(()) = buffer_slice.map_async(wgpu::MapMode::Read).await {
         // Gets contents of buffer
         let data = buffer_slice.get_mapped_range();
         // Since contents are got in bytes, this converts these bytes back to u32

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -13,6 +13,7 @@ use std::{
     marker::PhantomData,
     ops::Range,
     pin::Pin,
+    sync::Arc,
     task::{self, Poll},
 };
 use wasm_bindgen::prelude::*;
@@ -906,7 +907,7 @@ impl crate::Context for Context {
     }
 
     fn instance_request_adapter(
-        &self,
+        self: &Arc<Self>,
         options: &crate::RequestAdapterOptions<'_>,
     ) -> Self::RequestAdapterFuture {
         //TODO: support this check, return `None` if the flag is not set.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,7 @@ trait Context: Debug + Send + Sized + Sync {
         handle: &impl raw_window_handle::HasRawWindowHandle,
     ) -> Self::SurfaceId;
     fn instance_request_adapter(
-        &self,
+        self: &Arc<Self>,
         options: &RequestAdapterOptions<'_>,
     ) -> Self::RequestAdapterFuture;
     fn adapter_request_device(


### PR DESCRIPTION
One of the parts that's currently a bit confusing about async buffer mapping is how the device has to be manually polled after futures are created but before being awaited.

The device polling also doesn't exist in the upstream web API, so it would be nice to at least make it optional somehow (possibly opt-in if finer-grained control is needed).

In this PR we poll all devices continuously in a background thread. Futures will resolve automatically whenever the buffer mapping is ready. For example, we don't to use `force_wait` in order to read data back in the compute example or spin because the background thread is doing this for us already.

I'm interested in feedback about this approach and whether this is a good idea. I see a few pros and cons but hopefully some of the cons can be addressed later without API changes.

Pros:
- Slightly better alignment with web backend, since [this is similar to the approach gecko is using too](https://github.com/mozilla/gecko-dev/blob/6638e1d/dom/webgpu/ipc/WebGPUParent.cpp#L168)
- It's not necessary to manually call `device.poll` anymore because it will happen in the background
- We could probably remove `device.poll` entirely unless we want to allow for finer-grained control
- `Maintain::Wait` isn't portable to the web (e.g. it currently no-ops there) so this fixes a minor inconsistency which might not match expectations when targeting the web

Cons:
- A background thread is spinning and burning CPU cycles even though it might not be necessary (e.g. if no buffer mapping ever happens)
- Multiple threads are required for now when running on native, so we can't run on a single thread even for debugging
- A default interval of 100ms might cause longer waits for buffer mapping than using `wgpu::Maintain::Wait` (i.e. `force_wait` in wgpu)

Some future possibilities:
- We could open up more control over the thread (thread affinity, sleep interval/yielding continuously without waiting) or integrate with other threadpools if they're being used
- We could spin up/down threads if no futures/buffer mappings are currently pending
- We could probably make the spinloop a bit more smart by waiting different intervals depending on how much work is pending
- Maybe we could still make it work on a single thread for a (slow) debug by running with `force_wait`/spinning immediately whenever a future is created (i.e. basically blocking on buffer mapping whenever it happens)
- Maybe we'd be able to eventually eliminate most or all of the spinning internally without later API changes, and maybe even avoid creation of a thread in some cases (e.g. possibly epoll on Linux+Vulkan could be used, or timeline semaphores on Vulkan and similar concepts in other backends could be used)

We could also expose some way to opt-in or opt-out of the background thread/automatic polling to give users control over how polling should happen. This would allow people to have a choice about how polling should happen for the native backend (their own thread, blocking, etc.). For example, if we wanted to expose the ability to opt-out, we could have a function on the `Adapter` to disable it. In contrast, if we wanted to expose the ability to opt-in, we wouldn't launch a thread by default and instead expose a helper function that's able to create one (we could use the helper function in our examples).