### PR TITLE
Add Instance::poll_all

### DIFF
--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -688,6 +688,14 @@ impl crate::Context for Context {
         ready(id.ok())
     }
 
+    fn instance_poll_all_devices(&self, force_wait: bool) {
+        let global = &self.0;
+        match global.poll_all_devices(force_wait) {
+            Ok(()) => (),
+            Err(err) => self.handle_error_fatal(err, "Device::poll"),
+        }
+    }
+
     fn adapter_request_device(
         &self,
         adapter: &Self::AdapterId,

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -945,6 +945,10 @@ impl crate::Context for Context {
         )
     }
 
+    fn instance_poll_all_devices(&self, _force_wait: bool) {
+        // Devices are automatically polled.
+    }
+
     fn adapter_request_device(
         &self,
         adapter: &Self::AdapterId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,7 @@ trait Context: Debug + Send + Sized + Sync {
         desc: &DeviceDescriptor,
         trace_dir: Option<&std::path::Path>,
     ) -> Self::RequestDeviceFuture;
+    fn instance_poll_all_devices(&self, force_wait: bool);
     fn adapter_get_swap_chain_preferred_format(
         &self,
         adapter: &Self::AdapterId,
@@ -1389,6 +1390,13 @@ impl Instance {
         layer: *mut std::ffi::c_void,
     ) -> Surface {
         self.context.create_surface_from_core_animation_layer(layer)
+    }
+
+    /// Polls all devices.
+    /// If `force_wait` is true and this is not running on the web,
+    /// then this function will block until all in-flight buffers have been mapped.
+    pub fn poll_all(&self, force_wait: bool) {
+        self.context.instance_poll_all_devices(force_wait);
     }
 }
 


### PR DESCRIPTION
`Instance::poll_all` polls all devices. This will be useful for integrating into the winit event loop from a third-party crate.﻿
