### PR TITLE
Replace usage of futures with futures-util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ rev = "05a531191d4ce2927f2157e5dd54b7aa5d779406"
 
 [dependencies]
 arrayvec = "0.5"
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 parking_lot = "0.11"
 raw-window-handle = "0.3"
 smallvec = "1"

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -1,3 +1,13 @@
+use crate::{
+    BindGroupDescriptor, BindGroupLayoutDescriptor, BindingResource, BindingType,
+    BufferBindingType, BufferDescriptor, CommandEncoderDescriptor, ComputePassDescriptor,
+    ComputePipelineDescriptor, LoadOp, PipelineLayoutDescriptor, ProgrammableStageDescriptor,
+    RenderBundleEncoderDescriptor, RenderPipelineDescriptor, SamplerDescriptor,
+    ShaderModuleDescriptor, ShaderSource, StorageTextureAccess, SwapChainStatus, TextureDescriptor,
+    TextureViewDescriptor, TextureViewDimension,
+};
+
+use futures_util::FutureExt;
 use std::{
     collections::HashSet,
     fmt,
@@ -831,6 +841,10 @@ fn map_map_mode(mode: crate::MapMode) -> u32 {
 }
 
 type JsFutureResult = Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>;
+<<<<<<< Updated upstream
+=======
+type FutureMap<T> = futures_util::future::Map<wasm_bindgen_futures::JsFuture, fn(JsFutureResult) -> T>;
+>>>>>>> Stashed changes
 
 fn future_request_adapter(result: JsFutureResult) -> Option<Sendable<web_sys::GpuAdapter>> {
     match result {

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -841,10 +841,7 @@ fn map_map_mode(mode: crate::MapMode) -> u32 {
 }
 
 type JsFutureResult = Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>;
-<<<<<<< Updated upstream
-=======
 type FutureMap<T> = futures_util::future::Map<wasm_bindgen_futures::JsFuture, fn(JsFutureResult) -> T>;
->>>>>>> Stashed changes
 
 fn future_request_adapter(result: JsFutureResult) -> Option<Sendable<web_sys::GpuAdapter>> {
     match result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@ use std::{
     sync::Arc,
     thread,
 };
-
 use parking_lot::Mutex;
 
 pub use wgt::{


### PR DESCRIPTION
This crate relies on the `futures` crate, which is relatively heavy and provides a number of utilities that this crate doesn't really need. This pull request replaces all usages of `futures` with the smaller `futures-util` crate.