### PR TITLE
Panic on empty buffer slices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,20 +26,20 @@ webgl = ["wgc"]
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "2d0142a2e784ee46c7922ea759bb05128e8ba957"
+rev = "ce4668a7ac6a2cd43e0081166f6d0b7c4b7c2cde"
 features = ["raw-window-handle", "cross"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "2d0142a2e784ee46c7922ea759bb05128e8ba957"
+rev = "ce4668a7ac6a2cd43e0081166f6d0b7c4b7c2cde"
 features = ["raw-window-handle", "cross"]
 optional = true
 
 [dependencies.wgt]
 package = "wgpu-types"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "2d0142a2e784ee46c7922ea759bb05128e8ba957"
+rev = "ce4668a7ac6a2cd43e0081166f6d0b7c4b7c2cde"
 
 [dependencies]
 arrayvec = "0.5"


### PR DESCRIPTION
Fixes #735 
Can't really pass through zero sizes, so panic it is.

I'm really just here to update to latest wgpu version to get my recent fix there in a more convenient manner, but doing a PR with just that felt a bit boring ;-). Now I'm of course guilty of conflating things 🤔 