### PR TITLE
Return None from get_swap_chain_preferred_format if the adapter does not support the surface

### DIFF
--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -202,7 +202,7 @@ fn start<E: Example>(
     let spawner = Spawner::new();
     let mut sc_desc = wgpu::SwapChainDescriptor {
         usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
-        format: adapter.get_swap_chain_preferred_format(&surface),
+        format: adapter.get_swap_chain_preferred_format(&surface).unwrap(),
         width: size.width,
         height: size.height,
         present_mode: wgpu::PresentMode::Mailbox,

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -44,7 +44,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
         push_constant_ranges: &[],
     });
 
-    let swapchain_format = adapter.get_swap_chain_preferred_format(&surface);
+    let swapchain_format = adapter.get_swap_chain_preferred_format(&surface).unwrap();
 
     let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
         label: None,

--- a/examples/hello-windows/main.rs
+++ b/examples/hello-windows/main.rs
@@ -32,7 +32,7 @@ impl ViewportDesc {
 
         let sc_desc = wgpu::SwapChainDescriptor {
             usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
-            format: adapter.get_swap_chain_preferred_format(&self.surface),
+            format: adapter.get_swap_chain_preferred_format(&self.surface).unwrap(),
             width: size.width,
             height: size.height,
             present_mode: wgpu::PresentMode::Fifo,

--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -724,11 +724,12 @@ impl crate::Context for Context {
         &self,
         adapter: &Self::AdapterId,
         surface: &Self::SurfaceId,
-    ) -> TextureFormat {
+    ) -> Option<TextureFormat> {
         let global = &self.0;
         match wgc::gfx_select!(adapter => global.adapter_get_swap_chain_preferred_format(*adapter, *surface))
         {
-            Ok(swap_chain_preferred_format) => swap_chain_preferred_format,
+            Ok(swap_chain_preferred_format) => Some(swap_chain_preferred_format),
+            Err(wgc::instance::GetSwapChainPreferredFormatError::UnsupportedQueueFamily) => None,
             Err(err) => self.handle_error_fatal(err, "Adapter::get_swap_chain_preferred_format"),
         }
     }

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -980,9 +980,9 @@ impl crate::Context for Context {
         &self,
         _adapter: &Self::AdapterId,
         _surface: &Self::SurfaceId,
-    ) -> wgt::TextureFormat {
+    ) -> Option<wgt::TextureFormat> {
         // TODO: web-sys bindings need to be updated to not return a promise
-        wgt::TextureFormat::Bgra8Unorm
+        Some(wgt::TextureFormat::Bgra8Unorm)
     }
 
     fn adapter_features(&self, _adapter: &Self::AdapterId) -> wgt::Features {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ trait Context: Debug + Send + Sized + Sync {
         &self,
         adapter: &Self::AdapterId,
         surface: &Self::SurfaceId,
-    ) -> TextureFormat;
+    ) -> Option<TextureFormat>;
     fn adapter_features(&self, adapter: &Self::AdapterId) -> Features;
     fn adapter_limits(&self, adapter: &Self::AdapterId) -> Limits;
     fn adapter_get_info(&self, adapter: &Self::AdapterId) -> AdapterInfo;
@@ -1441,7 +1441,9 @@ impl Adapter {
     }
 
     /// Returns an optimal texture format to use for the [`SwapChain`] with this adapter.
-    pub fn get_swap_chain_preferred_format(&self, surface: &Surface) -> TextureFormat {
+    ///
+    /// Returns None if the surface is incompatible with the adapter.
+    pub fn get_swap_chain_preferred_format(&self, surface: &Surface) -> Option<TextureFormat> {
         Context::adapter_get_swap_chain_preferred_format(&*self.context, &self.id, &surface.id)
     }
 


### PR DESCRIPTION
Fixes #777 

Almost every other method in wgpu panics on failure, so I decided to make the return value an `Option<TextureFormat>`, not a `Result<Option<TextureFormat>>`