### PR TITLE
Mark BufferMappedRange Send/Sync on native

### DIFF
--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -1910,6 +1910,9 @@ pub struct BufferMappedRange {
     size: usize,
 }
 
+unsafe impl Send for BufferMappedRange {}
+unsafe impl Sync for BufferMappedRange {}
+
 impl crate::BufferMappedRangeSlice for BufferMappedRange {
     fn slice(&self) -> &[u8] {
         unsafe { slice::from_raw_parts(self.ptr, self.size) }


### PR DESCRIPTION
This fixes an issue reported on the matrix where this was causing things to unnecessarily be !Send. There's no reason I can see that this couldn't be Send/Sync as we only use it like one would a slice. We might also consider backporting this to 0.7.