### PR TITLE
Fix excessive buffer padding

### DIFF
--- a/src/util/device.rs
+++ b/src/util/device.rs
@@ -37,8 +37,10 @@ pub trait DeviceExt {
 impl DeviceExt for crate::Device {
     fn create_buffer_init(&self, descriptor: &BufferInitDescriptor<'_>) -> crate::Buffer {
         let unpadded_size = descriptor.contents.len() as crate::BufferAddress;
-        let padding = crate::COPY_BUFFER_ALIGNMENT - unpadded_size % crate::COPY_BUFFER_ALIGNMENT;
-        let padded_size = padding + unpadded_size;
+        // Valid vulkan usage is
+        // 1. buffer size must be a multiple of COPY_BUFFER_ALIGNMENT.
+        // 2. buffer size must be greater than 0.
+        let padded_size = ((unpadded_size + crate::COPY_BUFFER_ALIGNMENT - 1) / crate::COPY_BUFFER_ALIGNMENT).max(1) * crate::COPY_BUFFER_ALIGNMENT;
 
         let wgt_descriptor = crate::BufferDescriptor {
             label: descriptor.label,

--- a/src/util/device.rs
+++ b/src/util/device.rs
@@ -1,5 +1,7 @@
 use std::convert::TryFrom;
 
+use crate::COPY_BUFFER_ALIGNMENT;
+
 /// Describes a [Buffer](crate::Buffer) when allocating.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct BufferInitDescriptor<'a> {
@@ -40,7 +42,7 @@ impl DeviceExt for crate::Device {
         // Valid vulkan usage is
         // 1. buffer size must be a multiple of COPY_BUFFER_ALIGNMENT.
         // 2. buffer size must be greater than 0.
-        let padded_size = ((unpadded_size + crate::COPY_BUFFER_ALIGNMENT - 1) / crate::COPY_BUFFER_ALIGNMENT).max(1) * crate::COPY_BUFFER_ALIGNMENT;
+        let padded_size = ((unpadded_size + COPY_BUFFER_ALIGNMENT - 1) / COPY_BUFFER_ALIGNMENT).max(1) * COPY_BUFFER_ALIGNMENT;
 
         let wgt_descriptor = crate::BufferDescriptor {
             label: descriptor.label,

--- a/src/util/device.rs
+++ b/src/util/device.rs
@@ -1,7 +1,5 @@
 use std::convert::TryFrom;
 
-use crate::COPY_BUFFER_ALIGNMENT;
-
 /// Describes a [Buffer](crate::Buffer) when allocating.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct BufferInitDescriptor<'a> {
@@ -43,8 +41,8 @@ impl DeviceExt for crate::Device {
         // 1. buffer size must be a multiple of COPY_BUFFER_ALIGNMENT.
         // 2. buffer size must be greater than 0.
         // Therefore we round the value up to the nearest multiple, and ensure it's at least COPY_BUFFER_ALIGNMENT.
-        let align_mask = COPY_BUFFER_ALIGNMENT - 1;
-        let padded_size = ((unpadded_size + align_mask) & !align_mask).max(COPY_BUFFER_ALIGNMENT);
+        let align_mask = crate::COPY_BUFFER_ALIGNMENT - 1;
+        let padded_size = ((unpadded_size + align_mask) & !align_mask).max(crate::COPY_BUFFER_ALIGNMENT);
 
         let wgt_descriptor = crate::BufferDescriptor {
             label: descriptor.label,

--- a/src/util/device.rs
+++ b/src/util/device.rs
@@ -42,7 +42,9 @@ impl DeviceExt for crate::Device {
         // Valid vulkan usage is
         // 1. buffer size must be a multiple of COPY_BUFFER_ALIGNMENT.
         // 2. buffer size must be greater than 0.
-        let padded_size = ((unpadded_size + COPY_BUFFER_ALIGNMENT - 1) / COPY_BUFFER_ALIGNMENT).max(1) * COPY_BUFFER_ALIGNMENT;
+        let padded_size = ((unpadded_size + COPY_BUFFER_ALIGNMENT - 1) / COPY_BUFFER_ALIGNMENT)
+            .max(1)
+            * COPY_BUFFER_ALIGNMENT;
 
         let wgt_descriptor = crate::BufferDescriptor {
             label: descriptor.label,

--- a/src/util/device.rs
+++ b/src/util/device.rs
@@ -42,9 +42,9 @@ impl DeviceExt for crate::Device {
         // Valid vulkan usage is
         // 1. buffer size must be a multiple of COPY_BUFFER_ALIGNMENT.
         // 2. buffer size must be greater than 0.
-        let padded_size = ((unpadded_size + COPY_BUFFER_ALIGNMENT - 1) / COPY_BUFFER_ALIGNMENT)
-            .max(1)
-            * COPY_BUFFER_ALIGNMENT;
+        // Therefore we round the value up to the nearest multiple, and ensure it's at least COPY_BUFFER_ALIGNMENT.
+        let align_mask = COPY_BUFFER_ALIGNMENT - 1;
+        let padded_size = ((unpadded_size + align_mask) & !align_mask).max(COPY_BUFFER_ALIGNMENT);
 
         let wgt_descriptor = crate::BufferDescriptor {
             label: descriptor.label,


### PR DESCRIPTION
Previously buffers sizes which were already aligned would be unnecessarily padded with `COPY_BUFFER_ALIGNMENT` (4) bytes.
