### PR TITLE
Schedule event waits after redraw events are cleared

### DIFF
--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -221,7 +221,7 @@ fn start<E: Example>(
             ControlFlow::Poll
         };
         match event {
-            event::Event::MainEventsCleared => {
+            event::Event::RedrawEventsCleared => {
                 #[cfg(not(target_arch = "wasm32"))]
                 {
                     // Clamp to some max framerate to avoid busy-looping too much

--- a/examples/hello-triangle/main.rs
+++ b/examples/hello-triangle/main.rs
@@ -80,7 +80,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
         // the resources are properly cleaned up.
         let _ = (&instance, &adapter, &shader, &pipeline_layout);
 
-        *control_flow = ControlFlow::Poll;
+        *control_flow = ControlFlow::Wait;
         match event {
             Event::WindowEvent {
                 event: WindowEvent::Resized(size),


### PR DESCRIPTION
As @adamnemecek pointed out, our examples were busy waiting.
I investigated a bit and figured that our `WaitScheduled` was always interrupted by `RedrawEventsCleared`. So scheduling the wait in it works. Tested on Linux and macOS. CPU time of the cube example drops from 100% to single-digit.