### PR TITLE
Add overflow detection to hello-compute

### DIFF
--- a/examples/hello-compute/shader.wgsl
+++ b/examples/hello-compute/shader.wgsl
@@ -23,6 +23,11 @@ fn collatz_iterations(n_base: u32) -> u32{
             n = n / 2u;
         }
         else {
+            // Overflow? (i.e. 3*n + 1 > 0xffffffffu?)
+            if (n >= 1431655765u) {   // 0x55555555u
+                return 4294967295u;   // 0xffffffffu
+            }
+
             n = 3u * n + 1u;
         }
         i = i + 1u;


### PR DESCRIPTION
Description
The `hello-compute` example sometimes gives incorrect results if an intermediate Collatz value overflows. 

Proposed Solution
We can detect overflows before they occur, since the `3n+1` step is the only possible overflow. (WGSL only supports u32.)

Example
`cargo run --example hello-compute 77031 837799 8400511 63728127` 
> Incorrect Current Output: `[350, 524, 312, 346]`
> Correct Output: `[350, 524, 685, 949]`
> Proposed Solution: `[350, 524, OVERFLOW, OVERFLOW]`

Notes
- The `hello-compute` example appears to be [borrowed from naga](https://github.com/gfx-rs/naga/blob/master/tests/in/collatz.wgsl), so this would cause the implementations to differ.
- Hexadecimal literals are not yet implemented in naga for WGSL shaders, so the shader literals are not as pretty as they could be.
- Revised terminology `times` -> `steps` to be consistent with [Wikipedia](https://en.wikipedia.org/wiki/Collatz_conjecture).
