### PR TITLE
Specify size in `util::BufferInitDescriptor`

### DIFF
--- a/examples/boids/main.rs
+++ b/examples/boids/main.rs
@@ -68,6 +68,7 @@ impl framework::Example for Example {
         let sim_param_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Simulation Parameter Buffer"),
             contents: bytemuck::cast_slice(&sim_param_data),
+            size: None,
             usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
         });
 
@@ -171,6 +172,7 @@ impl framework::Example for Example {
         let vertices_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Vertex Buffer"),
             contents: bytemuck::bytes_of(&vertex_buffer_data),
+            size: None,
             usage: wgpu::BufferUsage::VERTEX | wgpu::BufferUsage::COPY_DST,
         });
 
@@ -195,6 +197,7 @@ impl framework::Example for Example {
                 device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                     label: Some(&format!("Particle Buffer {}", i)),
                     contents: bytemuck::cast_slice(&initial_particle_data),
+                    size: None,
                     usage: wgpu::BufferUsage::VERTEX
                         | wgpu::BufferUsage::STORAGE
                         | wgpu::BufferUsage::COPY_DST,

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -127,12 +127,14 @@ impl framework::Example for Example {
         let vertex_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Vertex Buffer"),
             contents: bytemuck::cast_slice(&vertex_data),
+            size: None,
             usage: wgpu::BufferUsage::VERTEX,
         });
 
         let index_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Index Buffer"),
             contents: bytemuck::cast_slice(&index_data),
+            size: None,
             usage: wgpu::BufferUsage::INDEX,
         });
 
@@ -225,6 +227,7 @@ impl framework::Example for Example {
         let uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Uniform Buffer"),
             contents: bytemuck::cast_slice(mx_ref),
+            size: None,
             usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
         });
 

--- a/examples/hello-compute/main.rs
+++ b/examples/hello-compute/main.rs
@@ -92,6 +92,7 @@ async fn execute_gpu(numbers: Vec<u32>) -> Vec<u32> {
     let storage_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
         label: Some("Storage Buffer"),
         contents: bytemuck::cast_slice(&numbers),
+        size: None,
         usage: wgpu::BufferUsage::STORAGE
             | wgpu::BufferUsage::COPY_DST
             | wgpu::BufferUsage::COPY_SRC,

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -238,6 +238,7 @@ impl framework::Example for Example {
         let temp_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Temporary Buffer"),
             contents: texels.as_slice(),
+            size: None,
             usage: wgpu::BufferUsage::COPY_SRC,
         });
         init_encoder.copy_buffer_to_texture(
@@ -273,6 +274,7 @@ impl framework::Example for Example {
         let uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Uniform Buffer"),
             contents: bytemuck::cast_slice(mx_ref),
+            size: None,
             usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
         });
 

--- a/examples/msaa-line/main.rs
+++ b/examples/msaa-line/main.rs
@@ -165,6 +165,7 @@ impl framework::Example for Example {
         let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Vertex Buffer"),
             contents: bytemuck::cast_slice(&vertex_data),
+            size: None,
             usage: wgpu::BufferUsage::VERTEX,
         });
         let vertex_count = vertex_data.len() as u32;

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -205,6 +205,7 @@ impl framework::Example for Example {
             &wgpu::util::BufferInitDescriptor {
                 label: Some("Cubes Vertex Buffer"),
                 contents: bytemuck::cast_slice(&cube_vertex_data),
+                size: None,
                 usage: wgpu::BufferUsage::VERTEX,
             },
         ));
@@ -213,6 +214,7 @@ impl framework::Example for Example {
             &wgpu::util::BufferInitDescriptor {
                 label: Some("Cubes Index Buffer"),
                 contents: bytemuck::cast_slice(&cube_index_data),
+                size: None,
                 usage: wgpu::BufferUsage::INDEX,
             },
         ));
@@ -221,12 +223,14 @@ impl framework::Example for Example {
         let plane_vertex_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Plane Vertex Buffer"),
             contents: bytemuck::cast_slice(&plane_vertex_data),
+            size: None,
             usage: wgpu::BufferUsage::VERTEX,
         });
 
         let plane_index_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Plane Index Buffer"),
             contents: bytemuck::cast_slice(&plane_index_data),
+            size: None,
             usage: wgpu::BufferUsage::INDEX,
         });
 
@@ -573,6 +577,7 @@ impl framework::Example for Example {
             let uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                 label: Some("Uniform Buffer"),
                 contents: bytemuck::bytes_of(&forward_uniforms),
+                size: None,
                 usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
             });
 

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -107,6 +107,7 @@ impl framework::Example for Skybox {
                     let vertex_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                         label: Some("Vertex"),
                         contents: bytemuck::cast_slice(&vertices),
+                        size: None,
                         usage: wgpu::BufferUsage::VERTEX,
                     });
                     entities.push(Entity {
@@ -176,6 +177,7 @@ impl framework::Example for Skybox {
         let uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Buffer"),
             contents: bytemuck::cast_slice(&raw_uniforms),
+            size: None,
             usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
         });
 

--- a/examples/texture-arrays/main.rs
+++ b/examples/texture-arrays/main.rs
@@ -116,6 +116,7 @@ impl framework::Example for Example {
         let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Vertex Buffer"),
             contents: bytemuck::cast_slice(&vertex_data),
+            size: None,
             usage: wgpu::BufferUsage::VERTEX,
         });
 
@@ -123,6 +124,7 @@ impl framework::Example for Example {
         let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Index Buffer"),
             contents: bytemuck::cast_slice(&index_data),
+            size: None,
             usage: wgpu::BufferUsage::INDEX,
         });
 

--- a/examples/water/main.rs
+++ b/examples/water/main.rs
@@ -337,12 +337,14 @@ impl framework::Example for Example {
         let water_vertex_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Water vertices"),
             contents: bytemuck::cast_slice(&water_vertices),
+            size: None,
             usage: wgpu::BufferUsage::VERTEX,
         });
 
         let terrain_vertex_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Terrain vertices"),
             contents: bytemuck::cast_slice(&terrain_vertices),
+            size: None,
             usage: wgpu::BufferUsage::VERTEX,
         });
 


### PR DESCRIPTION
This PR adds the ability, to specify a size in the `util::BufferInitDescriptor`.
This can be of convenience, if you want to write new data after initialization, which is bigger than the original `contents`.

For this change a `size: Option<BufferAddress>` field was introduced it the `util::BufferInitDescriptor` and the code in the `util::DeviceExt::create_buffer_init` trait function impl for `Device` was adjusted.


If the `size` is unspecified (`None`), then the `contents.len()` is used.

The `size` must be at least as big as `contents.len()`. If this is not respected then the buffer creation panics.

I'm open for suggestions.
