### PR TITLE
[0.7] Require syn 1.0.65 for web backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,7 @@ web-sys = { version = "=0.3.46", features = [
 ]}
 js-sys = "0.3.46"
 wasm-bindgen-futures = "0.4.19"
-syn = { version = "=1.0.65", optional = true }
+syn = "=1.0.65"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 console_error_panic_hook = "0.1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,7 @@ web-sys = { version = "=0.3.46", features = [
 ]}
 js-sys = "0.3.46"
 wasm-bindgen-futures = "0.4.19"
+syn = { version = "=1.0.65", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 console_error_panic_hook = "0.1.6"


### PR DESCRIPTION
Alternative to #818

`syn` is already included by a transitive dependency that also has a fixed version here, so it doesn't need to be `optional`