### PR TITLE
Don't pin web-sys and wasm-bindgen versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
         run: cargo build --release --target wasm32-unknown-unknown --examples
 
       - name: Install wasm-bindgen-cli
-        run: cargo install --force wasm-bindgen-cli --version 0.2.73
+        run: cargo install wasm-bindgen-cli
 
       - name: Generate JS bindings for the examples
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ test = true
 #wasm-bindgen = { path = "../wasm-bindgen" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "=0.2.73" # remember to change version in wiki as well
+wasm-bindgen = "0.2.73" # remember to change version in wiki as well
 web-sys = { version = "=0.3.50", features = [
     "Document",
     "Navigator",


### PR DESCRIPTION
Pinning them forces all downstream dependencies to use exactly this version

The latest release of wgpu has pinned an old version of wasm-bindgen, forcing users to downgrade wasm-bindgen-cli in order to build