### PR TITLE
Add uniform and storage buffer arrays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,6 @@ all-features = true
 default = []
 trace = ["serde", "wgc/trace"]
 replay = ["serde", "wgc/replay"]
-# Make Vulkan backend available on platforms where it is by default not, e.g. macOS
-vulkan-portability = ["wgc/gfx-backend-vulkan"]
 webgl = ["wgc"]
 # Enable SPIRV-Cross
 cross = ["wgc/cross"]
@@ -28,20 +26,20 @@ cross = ["wgc/cross"]
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "13015c8621daade1decb7e1083b7e0f73eeab6c7"
+rev = "e5ddb94be0221b0f53a8f43adfb15458daebfd7c"
 features = ["raw-window-handle"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "13015c8621daade1decb7e1083b7e0f73eeab6c7"
+rev = "e5ddb94be0221b0f53a8f43adfb15458daebfd7c"
 features = ["raw-window-handle"]
 optional = true
 
 [dependencies.wgt]
 package = "wgpu-types"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "13015c8621daade1decb7e1083b7e0f73eeab6c7"
+rev = "e5ddb94be0221b0f53a8f43adfb15458daebfd7c"
 
 [dependencies]
 arrayvec = "0.5"

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -349,11 +349,11 @@ impl framework::Example for Example {
             layout: &local_bind_group_layout,
             entries: &[wgpu::BindGroupEntry {
                 binding: 0,
-                resource: wgpu::BindingResource::Buffer {
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
                     buffer: &entity_uniform_buf,
                     offset: 0,
                     size: wgpu::BufferSize::new(entity_uniform_size),
-                },
+                }),
             }],
             label: None,
         });

--- a/src/backend/web.rs
+++ b/src/backend/web.rs
@@ -1267,11 +1267,11 @@ impl crate::Context for Context {
             .iter()
             .map(|binding| {
                 let mapped_resource = match binding.resource {
-                    crate::BindingResource::Buffer {
+                    crate::BindingResource::Buffer(crate::BufferBinding {
                         ref buffer,
                         offset,
                         size,
-                    } => {
+                    }) => {
                         let mut mapped_buffer_binding =
                             web_sys::GpuBufferBinding::new(&buffer.id.0);
                         mapped_buffer_binding.offset(offset as f64);
@@ -1279,6 +1279,9 @@ impl crate::Context for Context {
                             mapped_buffer_binding.size(s.get() as f64);
                         }
                         JsValue::from(mapped_buffer_binding.clone())
+                    }
+                    crate::BindingResource::BufferArray(..) => {
+                        panic!("Web backend does not support arrays of buffers")
                     }
                     crate::BindingResource::Sampler(ref sampler) => {
                         JsValue::from(sampler.id.0.clone())


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/pull/1315

**Description**
Adds uniform and storage buffer arrays

Usage:
```
wgpu::BindGroupEntry {
    binding: 0,
    resource: BindingResource::BufferArray(&[
        buffer1.as_entire_buffer_binding(),
        buffer2.as_entire_buffer_binding(),
    ]),
}
```

