### PR TITLE
Add map alignment from wgpu-types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,20 +28,20 @@ cross = ["wgc/cross"]
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "27dbf076d5e257e14c816b052fcfdb25c165eda3"
+rev = "c820cc8e737e3773c9c28ec49a1fecd8fa273dab"
 features = ["raw-window-handle"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "27dbf076d5e257e14c816b052fcfdb25c165eda3"
+rev = "c820cc8e737e3773c9c28ec49a1fecd8fa273dab"
 features = ["raw-window-handle"]
 optional = true
 
 [dependencies.wgt]
 package = "wgpu-types"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "27dbf076d5e257e14c816b052fcfdb25c165eda3"
+rev = "c820cc8e737e3773c9c28ec49a1fecd8fa273dab"
 
 [dependencies]
 arrayvec = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub use wgt::{
     StencilState, StorageTextureAccess, SwapChainDescriptor, SwapChainStatus, TextureAspect,
     TextureDimension, TextureFormat, TextureFormatFeatureFlags, TextureFormatFeatures,
     TextureSampleType, TextureUsage, TextureViewDimension, VertexAttribute, VertexFormat,
-    BIND_BUFFER_ALIGNMENT, COPY_BUFFER_ALIGNMENT, COPY_BYTES_PER_ROW_ALIGNMENT,
+    BIND_BUFFER_ALIGNMENT, COPY_BUFFER_ALIGNMENT, COPY_BYTES_PER_ROW_ALIGNMENT, MAP_ALIGNMENT,
     PUSH_CONSTANT_ALIGNMENT, QUERY_SET_MAX_QUERIES, QUERY_SIZE, VERTEX_STRIDE_ALIGNMENT,
 };
 

--- a/src/util/belt.rs
+++ b/src/util/belt.rs
@@ -129,9 +129,9 @@ impl StagingBelt {
         encoder.copy_buffer_to_buffer(&chunk.buffer, chunk.offset, target, offset, size.get());
         let old_offset = chunk.offset;
         chunk.offset += size.get();
-        let remainder = chunk.offset % crate::COPY_BUFFER_ALIGNMENT;
+        let remainder = chunk.offset % crate::MAP_ALIGNMENT;
         if remainder != 0 {
-            chunk.offset += crate::COPY_BUFFER_ALIGNMENT - remainder;
+            chunk.offset += crate::MAP_ALIGNMENT - remainder;
         }
 
         self.active_chunks.push(chunk);


### PR DESCRIPTION
   References new type created in wgpu-types: https://github.com/gfx-rs/wgpu/pull/1322
  
   Aligns the map to new validations. Fixes stagingbelt only aligning to 4 bytes instead of the needed 8