### PR TITLE
Remove comment about `Vec::remove_item`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -556,7 +556,6 @@ impl MapContext {
             None => self.initial_range.end,
         };
 
-        // Switch this out with `Vec::remove_item` once that stabilizes.
         let index = self
             .sub_ranges
             .iter()


### PR DESCRIPTION
Sadly, `Vec::remove_item` was an unstable method that was deprecated and has now been removed.

https://github.com/rust-lang/rust/pull/80972

This pr removes a comment suggesting to use `Vec::remove_item` when it stabilizes.