### PR TITLE
Fix typos - it's -> its

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -980,7 +980,7 @@ pub enum BindingResource<'a> {
 
 /// Operation to perform to the output attachment at the start of a renderpass.
 ///
-/// The render target must be cleared at least once before it's content be loaded.
+/// The render target must be cleared at least once before its content is loaded.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "trace", derive(serde::Serialize))]
 #[cfg_attr(feature = "replay", derive(serde::Deserialize))]

--- a/src/util/device.rs
+++ b/src/util/device.rs
@@ -101,7 +101,7 @@ impl DeviceExt for crate::Device {
 
                 // When uploading mips of compressed textures and the mip is supposed to be
                 // a size that isn't a multiple of the block size, the mip needs to be uploaded
-                // as it's "physical size" which is the size rounded up to the nearest block size.
+                // as its "physical size" which is the size rounded up to the nearest block size.
                 let mip_physical = mip_size.physical_size(desc.format);
 
                 // All these calculations are performed on the physical size as that's the


### PR DESCRIPTION
As I was reading the documentation, I found an instance where "it's" should actually be "its", as it is used as a possessive, not a contraction. I fixed that and `grep`ed for other instances, of which I found one and fixed as well.