### PR TITLE
Remove glslangvalidator requirements from water example

### DIFF
--- a/examples/water/README.md
+++ b/examples/water/README.md
@@ -19,10 +19,6 @@ water
 ```
 cargo run --example water
 ```
-## To recompile shaders 
-(requires make and `glslangvalidator`)
-```
-make
-```
+
 ## Screenshot
 ![Water example](./screenshot.png)


### PR DESCRIPTION
`glslangvalidator` is no longer needed because the example uses WGSL.