### PR TITLE
Fix initializing buffer with unaligned data

### DIFF
--- a/src/util/device.rs
+++ b/src/util/device.rs
@@ -65,9 +65,7 @@ impl DeviceExt for crate::Device {
 
             let buffer = self.create_buffer(&wgt_descriptor);
 
-            buffer
-                .slice(..unpadded_size)
-                .get_mapped_range_mut()
+            buffer.slice(..).get_mapped_range_mut()[..unpadded_size as usize]
                 .copy_from_slice(descriptor.contents);
             buffer.unmap();
 


### PR DESCRIPTION
In wgpu 0.7, this was a valid operation, the zero padding was done by hand. 
In #872 this logic was removed as an optimization since buffers are already zero initialized, however the slice end was taken from buffer.slice which has to be aligned when mapped.

This is causing issues when trying to update imgui-wgpu-rs (https://github.com/Yatekii/imgui-wgpu-rs/issues/54) to  wgpu 0.8 since they  use U16 index buffers with odd lengths.