### PR TITLE
Fill Out Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug Report
+about: Create a bug report about either the native/wasm wrapper layer or the utility library.
+title: ''
+labels: bug
+assignees: ''
+---
+
+<!-- Thank you for filing this! If this is an issue with the core library, validation, or the backends, please file an issue on the wgpu-core tracker here: https://github.com/gfx-rs/wgpu/issues/new/choose-->
+
+**Description**
+A clear and concise description of what the bug is.
+
+**Repro steps**
+Ideally, a runnable example we can check out.
+
+**Expected vs observed behavior**
+Clearly describe what you get, and how it goes across your expectations.
+
+**Extra materials**
+Screenshots to help explain your problem.
+Validation logs can be attached in case there are warnings and errors.
+Zip-compressed API traces and GPU captures can also land here.
+
+**Platform**
+Information about your OS, version of `wgpu`, your tech stack, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Issue or enhancement in wgpu-core
+    url: https://github.com/gfx-rs/wgpu/issues/new/choose
+    about: Issues with or enhancements for the core logic, validation, or the backends should go here.
+  - name: Question about wgpu
+    url: https://github.com/gfx-rs/wgpu-rs/discussions/new
+    about: Any questions about how to use wgpu should go here.

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,0 +1,7 @@
+---
+name: Other
+about: Strange things you want to tell us
+title: ''
+labels: question
+assignees: ''
+---


### PR DESCRIPTION
This adds issue templates, as well as links to the wgpu-core tracker and the discussion board. Hopefully this should reduce the amount of issues we have to transfer.