### PR TITLE
Specify latest gfx release branch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ tracing = { version = "0.1", features = ["log-always"] }
 
 ## Development
 
-If you need to test local fixes to gfx-rs or other dependencies, the simplest way is to add a Cargo patch. For example, when working on DX12 backend on Windows, you can check out the "hal-0.2" branch of gfx-rs repo and add this to the end of "Cargo.toml":
+If you need to test local fixes to gfx or other dependencies, the simplest way is to add a Cargo patch. For example, when working on DX12 backend on Windows, you can check out the latest release branch in the [gfx-hal repository](https://github.com/gfx-rs/gfx) (e.g. currently `hal-0.8`) and add this patch to the end of `Cargo.toml`:
 
 ```toml
 [patch."https://github.com/gfx-rs/gfx"]


### PR DESCRIPTION
Specify latest gfx release branch in README, to hopefully avoid people checking out `hal-0.2` then wondering why the patch doesn't seem to do anything.