### PR TITLE
Handle winit exception in web to avoid breaking async executor

### DIFF
--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -338,10 +338,31 @@ pub fn run<E: Example>(title: &str) {
 
 #[cfg(target_arch = "wasm32")]
 pub fn run<E: Example>(title: &str) {
+    use wasm_bindgen::{prelude::*, JsCast};
+
     let title = title.to_owned();
     wasm_bindgen_futures::spawn_local(async move {
         let setup = setup::<E>(&title).await;
-        start::<E>(setup);
+        let start_closure = Closure::once_into_js(move || start::<E>(setup));
+
+        // make sure to handle JS exceptions thrown inside start.
+        // Otherwise wasm_bindgen_futures Queue would break and never handle any tasks again.
+        // This is required, because winit uses JS exception for control flow to escape from `run`.
+        if let Err(error) = call_catch(&start_closure) {
+            let is_control_flow_exception = error.dyn_ref::<js_sys::Error>().map_or(false, |e| {
+                e.message().includes("Using exceptions for control flow", 0)
+            });
+
+            if !is_control_flow_exception {
+                web_sys::console::error_1(&error);
+            }
+        }
+
+        #[wasm_bindgen]
+        extern "C" {
+            #[wasm_bindgen(catch, js_namespace = Function, js_name = "prototype.call.call")]
+            fn call_catch(this: &JsValue) -> Result<(), JsValue>;
+        }
     });
 }
 

--- a/src/backend/direct.rs
+++ b/src/backend/direct.rs
@@ -1938,7 +1938,7 @@ impl fmt::Debug for ErrorSinkRaw {
 }
 
 fn default_error_handler(err: crate::Error) {
-    eprintln!("wgpu error: {}\n", err);
+    log::error!("wgpu error: {}\n", err);
 
     panic!("Handling wgpu errors as fatal by default");
 }


### PR DESCRIPTION
In web environment, winit throws an "not an error" JS exception in order to satisfy the `!` return type of `EventLoop::run`. We encounter that inside our `start` function, which in turn is being run inside `wasm_bindgen_futures::spawn_local`. Unfortunately, `spawn_local` executor doesn't account for JS exception, and silently enters broken state where no more futures would ever run.

In detail, the `is_spinning` flag inside the executor is being set when the tasks are being polled. The flag is only reset once all tasks are polled. This flag prevents the executor from scheduling next queue processing, which is reasonable in the event of scheduling more tasks from inside already running task. The queue will be processed to the end anyway in the same JS microtask. Unfortunately because of the exception, the processing returns early and the flag is never being reset, thus preventing the queue from being processed ever again.

I've noticed this behaviour by observing that `StagingBelt` never reuses staging buffers in web environment. This is caused by `StagingBelt::recall` future never being polled.

The fix is to catch the JS exception, which is a bit tricky from inside the rust code. I did this by coercing `wasm_bindgen` to generate a function which can call other functions in a try block, using `Function.prototype.call.call(closure)`. The added benefit is that we can now detect and silence the annoying winit exception. All other exceptions are being printed into the console directly, still avoiding the executor broken state.

Fixes #454